### PR TITLE
Add AdvancedParameter with Uncertainties and Boundaries Support

### DIFF
--- a/src/BuildConstructors.jl
+++ b/src/BuildConstructors.jl
@@ -12,12 +12,18 @@ export Fixed
 export Running
 include("parameters.jl")
 
-export Parameter
+# export Parameter # not exported to avoid conflicts
 export fix!
 export release!
 export update!
-export pickup
+export running_values
 include("fix-release-pickup-update.jl")
+
+export AdvancedParameter
+export running_uncertainties
+export running_upper_boundaries
+export running_lower_boundaries
+include("boundary-error.jl")
 
 export build_model
 export ConstructorOfBW

--- a/src/abstract-constructor.jl
+++ b/src/abstract-constructor.jl
@@ -10,10 +10,13 @@ for func in (:fix!, :release!, :update!)
 end
 
 # collection functionality
-function pickup(c::AbstractConstructor)
-    _list = NamedTuple()
-    for field in fieldnames(typeof(c))
-        _list = merge(_list, pickup(getfield(c, field)))
+for func in (:running_values, :running_uncertainties, :running_upper_boundaries, :running_lower_boundaries)
+    @eval function $func(c::AbstractConstructor)
+        _list = NamedTuple()
+        for field in fieldnames(typeof(c))
+            _list = merge(_list, $func(getfield(c, field)))
+        end
+        return _list
     end
-    return _list
 end
+

--- a/src/boundary-error.jl
+++ b/src/boundary-error.jl
@@ -1,0 +1,45 @@
+mutable struct AdvancedParameter <: AbstractParameter
+    name::String
+    value::Float64
+    boundaries::Tuple{Float64,Float64}
+    uncertainty::Float64
+    fixed::Bool
+end
+BuildConstructors.value(p::AdvancedParameter; pars) =
+    p.fixed ? p.value : getproperty(pars, Symbol(p.name))
+AdvancedParameter(name, value; boundaries=(Inf, -Inf), uncertainty=1.0) =
+    AdvancedParameter(name, value, boundaries, uncertainty, false)
+
+
+fix!(p::AdvancedParameter, par_names) =
+    Symbol(p.name) ∈ par_names ? setfield!(p, :fixed, true) : nothing
+
+release!(p::AdvancedParameter, par_names) =
+    Symbol(p.name) ∈ par_names ? setfield!(p, :fixed, false) : nothing
+
+update!(c::AdvancedParameter, pars) =
+    Symbol(c.name) ∈ keys(pars) ? setfield!(c, :value, getproperty(pars, Symbol(c.name))) :
+    nothing
+
+running_values(c::AdvancedParameter) = NamedTuple{(Symbol(c.name),)}((c.value,))
+
+running_uncertainties(p::AdvancedParameter) = NamedTuple{(Symbol(p.name),)}((p.uncertainty,))
+running_uncertainties(p::Running) = NamedTuple{(Symbol(p.name),)}((missing,))
+running_uncertainties(p::Parameter) = NamedTuple{(Symbol(p.name),)}((missing,))
+running_uncertainties(p::Fixed) = NamedTuple()
+running_uncertainties(p::Tuple) = NamedTuple()
+running_uncertainties(p::Number) = NamedTuple()
+# 
+running_upper_boundaries(p::AdvancedParameter) = NamedTuple{(Symbol(p.name),)}((p.boundaries[2],))
+running_lower_boundaries(p::AdvancedParameter) = NamedTuple{(Symbol(p.name),)}((p.boundaries[1],))
+running_upper_boundaries(p::Parameter) = NamedTuple{(Symbol(p.name),)}((Inf,))
+running_lower_boundaries(p::Parameter) = NamedTuple{(Symbol(p.name),)}((-Inf,))
+running_upper_boundaries(c::Running) = NamedTuple{(Symbol(c.name),)}((Inf,))
+running_lower_boundaries(c::Running) = NamedTuple{(Symbol(c.name),)}((-Inf,))
+
+running_upper_boundaries(c::Fixed) = NamedTuple()
+running_upper_boundaries(c::Tuple) = NamedTuple()
+running_upper_boundaries(c::Number) = NamedTuple()
+running_lower_boundaries(c::Fixed) = NamedTuple()
+running_lower_boundaries(c::Tuple) = NamedTuple()
+running_lower_boundaries(c::Number) = NamedTuple()

--- a/src/fix-release-pickup-update.jl
+++ b/src/fix-release-pickup-update.jl
@@ -9,7 +9,7 @@ Parameter(name, value) = Parameter(name, value, false)
 
 
 # no arguments: fix all parameters
-fix!(c) = fix!(c, keys(pickup(c)))
+fix!(c) = fix!(c, keys(running_values(c)))
 # 
 fix!(p::BuildConstructors.AbstractParameter, par_names) = nothing
 fix!(p::Parameter, par_names) =
@@ -19,7 +19,7 @@ fix!(p::NamedTuple, par_names) = nothing
 fix!(p::Number, par_names) = nothing
 
 # no arguments: release all parameters
-release!(c) = release!(c, keys(pickup(c)))
+release!(c) = release!(c, keys(running_values(c)))
 # 
 release!(p::BuildConstructors.AbstractParameter, par_names) = nothing
 release!(p::Parameter, par_names) =
@@ -37,9 +37,9 @@ update!(c::Tuple, pars) = nothing
 update!(c::NamedTuple, pars) = nothing
 update!(c::Number, pars) = nothing
 
-
-pickup(c::Parameter) = NamedTuple{(Symbol(c.name),)}((c.value,))
-pickup(c::Running) = NamedTuple{(Symbol(c.name),)}((c.value,))
-pickup(c::Fixed) = NamedTuple()
-pickup(c::Tuple) = NamedTuple()
-pickup(c::Number) = NamedTuple()
+# retrieve the value of the parameter
+running_values(c::Parameter) = NamedTuple{(Symbol(c.name),)}((c.value,))
+running_values(c::Running) = NamedTuple{(Symbol(c.name),)}((missing,))
+running_values(c::Fixed) = NamedTuple()
+running_values(c::Tuple) = NamedTuple()
+running_values(c::Number) = NamedTuple()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using Distributions
 using NumericalDistributions
 using JSON
 
+import BuildConstructors: Parameter
 
 @testset "BuildConstructors tests" begin
     # let # to be replaced by the line above once working

--- a/test/test-parameter.jl
+++ b/test/test-parameter.jl
@@ -2,12 +2,14 @@ using BuildConstructors
 using ComponentArrays
 using Test
 
+import BuildConstructors: Parameter
+
 constructor = ConstructorOfPRBModel(
     ConstructorOfBW(Parameter("m", 2.0), Parameter("Γ", 0.2), (1.0, 2.5)),
-    ConstructorOfGaussian(Fixed(0.0), Parameter("σ", 0.1), (-0.5, 0.5)),
+    ConstructorOfGaussian(Fixed(0.0), Running("σ"), (-0.5, 0.5)),
     ConstructorOfPol1(Parameter("c1", 0.3), (1.0, 2.5)),
-    Parameter("fs", 0.5),
-    (1.0, 2.5),
+    AdvancedParameter("fs", 0.5; boundaries=(0.0, 1.0), uncertainty=0.01),
+    (1.0, 2.5)
 )
 
 @testset "Parameter is mutable" begin
@@ -49,18 +51,19 @@ end
     @test constructor.model_b.description_of_c1C.fixed == false
 end
 
+
 @testset "Update and pickup" begin
-    @test pickup(constructor.model_p) == (m = 2.0, Γ = 0.2)
+    @test running_values(constructor.model_p) == (m = 2.0, Γ = 0.2)
     update!(constructor.model_p, (m = 1.9, Γ = 0.1))
-    @test pickup(constructor.model_p) == (m = 1.9, Γ = 0.1)
-    @test pickup(constructor) |> keys == (:m, :Γ, :σ, :c1, :fs)
+    @test running_values(constructor.model_p) == (m = 1.9, Γ = 0.1)
+    @test running_values(constructor) |> keys == (:m, :Γ, :σ, :c1, :fs)
     update!(constructor.model_p, (m = 2.0, Γ = 0.2))
 end
 
 @testset "Update works with ComponentArray" begin
-    @test pickup(constructor.model_p) == (m = 2.0, Γ = 0.2)
+    @test running_values(constructor.model_p) == (m = 2.0, Γ = 0.2)
     update!(constructor.model_p, ComponentArray(m = 1.9, Γ = 0.1))
-    @test pickup(constructor.model_p) == (m = 1.9, Γ = 0.1)
+    @test running_values(constructor.model_p) == (m = 1.9, Γ = 0.1)
     update!(constructor.model_p, (m = 2.0, Γ = 0.2))
 end
 
@@ -68,13 +71,79 @@ end
     release!(constructor)
     @test constructor.model_p.description_of_m.fixed == false
     @test constructor.model_p.description_of_Γ.fixed == false
-    @test constructor.model_r.description_of_σ.fixed == false
     @test constructor.model_b.description_of_c1C.fixed == false
     @test constructor.description_of_fs.fixed == false
     fix!(constructor)
     @test constructor.model_p.description_of_m.fixed == true
     @test constructor.model_p.description_of_Γ.fixed == true
-    @test constructor.model_r.description_of_σ.fixed == true
     @test constructor.model_b.description_of_c1C.fixed == true
     @test constructor.description_of_fs.fixed == true
+end
+
+@testset "running_uncertainties" begin
+    # Test on Running
+    r = Running("σ")
+    @test running_uncertainties(r) === (σ = missing,)
+    
+    # Test on Fixed
+    f = Fixed(0.5)
+    @test running_uncertainties(f) == NamedTuple()
+    
+    # Test on constructor - should collect from all fields
+    # The constructor has: Parameter("m"), Parameter("Γ"), Fixed(0.0), Running("σ"), Parameter("c1"), Parameter("fs")
+    # Only Running("σ") should contribute
+    @test running_uncertainties(constructor) === (m = missing, Γ = missing, σ = missing, c1 = missing, fs = 0.01)
+    @test keys(running_uncertainties(constructor)) == keys(running_values(constructor))
+end
+
+@testset "running_upper_boundaries" begin
+    # Test on individual Parameter
+    p = Parameter("test", 1.0)
+    @test running_upper_boundaries(p) == (test = Inf,)
+    
+    # Test on Running
+    r = Running("σ")
+    @test running_upper_boundaries(r) == (σ = Inf,)
+    
+    # Test on Fixed
+    f = Fixed(0.5)
+    @test running_upper_boundaries(f) == NamedTuple()
+
+    # Test on constructor - should collect from all fields
+    # The constructor has: Parameter("m"), Parameter("Γ"), Fixed(0.0), Running("σ"), Parameter("c1"), Parameter("fs")
+    # All Parameters and Running should contribute with Inf
+    upper_bounds = running_upper_boundaries(constructor)
+    @test keys(upper_bounds) == keys(running_values(constructor))
+    @test upper_bounds.m == Inf
+    @test upper_bounds.Γ == Inf
+    @test upper_bounds.σ == Inf
+    @test upper_bounds.c1 == Inf
+    @test upper_bounds.fs == 1.0
+    @test keys(upper_bounds) == (:m, :Γ, :σ, :c1, :fs)
+end
+
+@testset "running_lower_boundaries" begin
+    # Test on individual Parameter
+    p = Parameter("test", 1.0)
+    @test running_lower_boundaries(p) == (test = -Inf,)
+    
+    # Test on Running
+    r = Running("σ")
+    @test running_lower_boundaries(r) == (σ = -Inf,)
+    
+    # Test on Fixed
+    f = Fixed(0.5)
+    @test running_lower_boundaries(f) == NamedTuple()
+    
+    # Test on constructor - should collect from all fields
+    # The constructor has: Parameter("m"), Parameter("Γ"), Fixed(0.0), Running("σ"), Parameter("c1"), Parameter("fs")
+    # All Parameters and Running should contribute with -Inf
+    lower_bounds = running_lower_boundaries(constructor)
+    @test keys(lower_bounds) == keys(running_values(constructor))
+    @test lower_bounds.m == -Inf
+    @test lower_bounds.Γ == -Inf
+    @test lower_bounds.σ == -Inf
+    @test lower_bounds.c1 == -Inf
+    @test lower_bounds.fs == 0.0
+    @test keys(lower_bounds) == (:m, :Γ, :σ, :c1, :fs)
 end


### PR DESCRIPTION
This PR introduces a new `AdvancedParameter` type that extends the parameter system with support for uncertainties and boundaries, enabling more sophisticated parameter constraints in model fitting. Additionally, it refactors the parameter collection mechanism to be more extensible and renames `pickup` to `running_values` for better clarity.

## Changes

### New Features

- **`AdvancedParameter` type**: A new mutable parameter type that extends `AbstractParameter` with:
  - **Boundaries**: Upper and lower limits for parameter constraints
  - **Uncertainties**: Associated uncertainty values for each parameter
  - Full support for `fix!`, `release!`, `update!`, and `running_values` operations

- **New collection functions**:
  - `running_uncertainties`: Collects uncertainty values from all running parameters in a constructor
  - `running_upper_boundaries`: Collects upper boundary values from all running parameters
  - `running_lower_boundaries`: Collects lower boundary values from all running parameters

### API Changes

- **Renamed**: `pickup` → `running_values` (more descriptive name)
- **Export changes**:
  - `Parameter` is no longer exported (to avoid naming conflicts; can still be imported with `import BuildConstructors: Parameter`)
  - New exports: `AdvancedParameter`, `running_uncertainties`, `running_upper_boundaries`, `running_lower_boundaries`

### Implementation Details

- Generalized the collection mechanism in `AbstractConstructor` to support multiple collection functions (`running_values`, `running_uncertainties`, `running_upper_boundaries`, `running_lower_boundaries`) through a generic dispatch pattern
- All parameter types (`Parameter`, `Running`, `Fixed`, `AdvancedParameter`) now implement the new collection functions with appropriate defaults:
  - `Running` and `Parameter`: Return `missing` for uncertainties and `±Inf` for boundaries
  - `Fixed`: Returns empty `NamedTuple()` for all collection functions
  - `AdvancedParameter`: Returns actual values for uncertainties and boundaries

## Usage Example

```julia
using BuildConstructors

# Create an advanced parameter with boundaries and uncertainty
fs = AdvancedParameter("fs", 0.5; boundaries=(0.0, 1.0), uncertainty=0.01)

# Use in a constructor
constructor = ConstructorOfPRBModel(
    ConstructorOfBW(Parameter("m", 2.0), Parameter("Γ", 0.2), (1.0, 2.5)),
    ConstructorOfGaussian(Fixed(0.0), Running("σ"), (-0.5, 0.5)),
    ConstructorOfPol1(Parameter("c1", 0.3), (1.0, 2.5)),
    fs,
    (1.0, 2.5)
)

# Collect uncertainties and boundaries
uncertainties = running_uncertainties(constructor)
upper_bounds = running_upper_boundaries(constructor)
lower_bounds = running_lower_boundaries(constructor)
```

## Testing

Comprehensive tests have been added in `test/test-parameter.jl` covering:
- `running_uncertainties` for all parameter types
- `running_upper_boundaries` for all parameter types
- `running_lower_boundaries` for all parameter types
- Integration with existing `fix!`, `release!`, and `update!` functionality

All existing tests continue to pass with the `pickup` → `running_values` rename.

## Breaking Changes

- `pickup` function has been renamed to `running_values`. Users will need to update their code to use the new name.
- `Parameter` is no longer exported. If needed, import it explicitly: `import BuildConstructors: Parameter`

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/mmikhasenko/HadronicLineshapes.jl/blob/main/docs/src/90-contributing.md)

- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
