### PR TITLE
Rename `Parameter` to `FlexibleParameter` and export it

### DIFF
--- a/data/database_from_prototype.json
+++ b/data/database_from_prototype.json
@@ -1,1 +1,35 @@
-{"sets":{"bin1":{"BG":{"support":[1.1,2.5],"method":"ConstructorOfPol1","pars":[{"c1":0.1}]},"RES":{"support":[-0.6,0.6],"method":"ConstructorOfZeroGaussian","pars":[{"σ":0.1}]}},"bin2":{"BG":{"support":[1.1,2.5],"method":"ConstructorOfPol1","pars":[{"c1":0.2}]},"RES":{"support":[-0.6,0.6],"method":"ConstructorOfGaussian","pars":[{"μ":0.0},{"σ":0.2}]}}},"physical":{"bw":{"support":[1.1,2.5],"method":"ConstructorOfBW","pars":[{"m":2.1},{"Γ":0.1}]}}}
+{
+  "sets": {
+    "bin1": {
+      "BG": {
+        "support": [1.1, 2.5],
+        "method": "ConstructorOfPol1",
+        "pars": [{ "c1": 0.1 }]
+      },
+      "RES": {
+        "support": [-0.6, 0.6],
+        "method": "ConstructorOfZeroGaussian",
+        "pars": [{ "σ": 0.1 }]
+      }
+    },
+    "bin2": {
+      "BG": {
+        "support": [1.1, 2.5],
+        "method": "ConstructorOfPol1",
+        "pars": [{ "c1": 0.2 }]
+      },
+      "RES": {
+        "support": [-0.6, 0.6],
+        "method": "ConstructorOfGaussian",
+        "pars": [{ "μ": 0.0 }, { "σ": 0.2 }]
+      }
+    }
+  },
+  "physical": {
+    "bw": {
+      "support": [1.1, 2.5],
+      "method": "ConstructorOfBW",
+      "pars": [{ "m": 2.1 }, { "Γ": 0.1 }]
+    }
+  }
+}

--- a/data/database_physical.json
+++ b/data/database_physical.json
@@ -1,49 +1,49 @@
 {
-    "bw": {
-      "type": "ConstructorOfBW",
-      "description_of_m": {
-        "type": "Running",
-        "name": "m",
-        "starting_value": 3871.8
-      },
-      "description_of_Γ": {
-        "type": "Running",
-        "name": "Γ",
-        "starting_value": 1.0
-      },
-      "support": [3845.32, 3904.27]
+  "bw": {
+    "type": "ConstructorOfBW",
+    "description_of_m": {
+      "type": "Running",
+      "name": "m",
+      "starting_value": 3871.8
     },
-    "flatte": {
-      "type": "ConstructorOfFlatte",
-      "description_of_Ef": {
-        "type": "Running",
-        "name": "Ef",
-        "starting_value": -7.66
-      },
-      "description_of_g": {
-        "type": "Running",
-        "name": "g",
-        "starting_value": 0.115
-      },
-      "description_of_Γ0": {
-        "type": "Running",
-        "name": "Γ0",
-        "starting_value": 1.88
-      },
-      "support": [-46.38, 52.57]
+    "description_of_Γ": {
+      "type": "Running",
+      "name": "Γ",
+      "starting_value": 1.0
     },
-    "braaten": {
-      "type": "Include",
-      "description_of_γre": {
-        "type": "Running",
-        "name": "γre",
-        "starting_value": 1.0
-      },
-      "description_of_γim": {
-        "type": "Running",
-        "name": "γim",
-        "starting_value": 0.01
-      },
+    "support": [3845.32, 3904.27]
+  },
+  "flatte": {
+    "type": "ConstructorOfFlatte",
+    "description_of_Ef": {
+      "type": "Running",
+      "name": "Ef",
+      "starting_value": -7.66
+    },
+    "description_of_g": {
+      "type": "Running",
+      "name": "g",
+      "starting_value": 0.115
+    },
+    "description_of_Γ0": {
+      "type": "Running",
+      "name": "Γ0",
+      "starting_value": 1.88
+    },
     "support": [-46.38, 52.57]
-    }
+  },
+  "braaten": {
+    "type": "Include",
+    "description_of_γre": {
+      "type": "Running",
+      "name": "γre",
+      "starting_value": 1.0
+    },
+    "description_of_γim": {
+      "type": "Running",
+      "name": "γim",
+      "starting_value": 0.01
+    },
+    "support": [-46.38, 52.57]
   }
+}

--- a/data/database_resolution.json
+++ b/data/database_resolution.json
@@ -1,39 +1,39 @@
 {
-    "CBpSECH": {
-      "type": "ConstructorOfCBpSECH",
-      "description_of_σ1": {
-        "type": "Fixed",
-        "value": 0.002795
-      },
-      "description_of_c0": {
-        "type": "Fixed",
-        "value": 2.48
-      },
-      "description_of_c1": {
-        "type": "Fixed",
-        "value": 474.0
-      },
-      "description_of_c2": {
-        "type": "Fixed",
-        "value": 8.1
-      },
-      "description_of_n": {
-        "type": "Fixed",
-        "value": 2.0
-      },
-      "description_of_s": {
-        "type": "Fixed",
-        "value": 1.3505
-      },
-      "description_of_fr1": {
-        "type": "Fixed",
-        "value": 0.5909
-      },
-      "description_of_w": {
-        "type": "Running",
-        "name": "w",
-        "starting_value": 0.9
-      },
-      "support": [-20.0, 20.0]
-    }
+  "CBpSECH": {
+    "type": "ConstructorOfCBpSECH",
+    "description_of_σ1": {
+      "type": "Fixed",
+      "value": 0.002795
+    },
+    "description_of_c0": {
+      "type": "Fixed",
+      "value": 2.48
+    },
+    "description_of_c1": {
+      "type": "Fixed",
+      "value": 474.0
+    },
+    "description_of_c2": {
+      "type": "Fixed",
+      "value": 8.1
+    },
+    "description_of_n": {
+      "type": "Fixed",
+      "value": 2.0
+    },
+    "description_of_s": {
+      "type": "Fixed",
+      "value": 1.3505
+    },
+    "description_of_fr1": {
+      "type": "Fixed",
+      "value": 0.5909
+    },
+    "description_of_w": {
+      "type": "Running",
+      "name": "w",
+      "starting_value": 0.9
+    },
+    "support": [-20.0, 20.0]
   }
+}

--- a/data/database_test.json
+++ b/data/database_test.json
@@ -113,9 +113,9 @@
     }
   },
   "description_of_fs": {
-        "type": "Running",
-        "name": "fs",
-        "starting_value": 0.5
-      },
+    "type": "Running",
+    "name": "fs",
+    "starting_value": 0.5
+  },
   "support": [-26.38, 32.57]
 }

--- a/src/BuildConstructors.jl
+++ b/src/BuildConstructors.jl
@@ -20,6 +20,7 @@ include("abstract-parameters.jl")
 
 export Fixed
 export Running
+export FlexibleParameter
 export AdvancedParameter
 include("concrete-parameters.jl")
 

--- a/src/concrete-parameters.jl
+++ b/src/concrete-parameters.jl
@@ -22,27 +22,27 @@ running_lower_boundaries(c::Running) = NamedTuple{(Symbol(c.name),)}((-Inf,))
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # mutable parameter, can be fixed and released
-mutable struct Parameter <: BuildConstructors.AbstractParameter
+mutable struct FlexibleParameter <: AbstractParameter
     name::String
     value::Float64
     fixed::Bool
 end
-value(p::Parameter; pars) = p.fixed ? p.value : getproperty(pars, Symbol(p.name))
-Parameter(name, value) = Parameter(name, value, false)
+value(p::FlexibleParameter; pars) = p.fixed ? p.value : getproperty(pars, Symbol(p.name))
+FlexibleParameter(name, value) = FlexibleParameter(name, value, false)
 
-fix!(p::Parameter, par_names) =
+fix!(p::FlexibleParameter, par_names) =
     Symbol(p.name) ∈ par_names ? setfield!(p, :fixed, true) : nothing
-release!(p::Parameter, par_names) =
+release!(p::FlexibleParameter, par_names) =
     Symbol(p.name) ∈ par_names ? setfield!(p, :fixed, false) : nothing
 
-update!(c::Parameter, pars) =
+update!(c::FlexibleParameter, pars) =
     Symbol(c.name) ∈ keys(pars) ? setfield!(c, :value, getproperty(pars, Symbol(c.name))) :
     nothing
 
-running_values(c::Parameter) = NamedTuple{(Symbol(c.name),)}((c.value,))
-running_uncertainties(p::Parameter) = NamedTuple{(Symbol(p.name),)}((missing,))
-running_upper_boundaries(p::Parameter) = NamedTuple{(Symbol(p.name),)}((Inf,))
-running_lower_boundaries(p::Parameter) = NamedTuple{(Symbol(p.name),)}((-Inf,))
+running_values(c::FlexibleParameter) = NamedTuple{(Symbol(c.name),)}((c.value,))
+running_uncertainties(p::FlexibleParameter) = NamedTuple{(Symbol(p.name),)}((missing,))
+running_upper_boundaries(p::FlexibleParameter) = NamedTuple{(Symbol(p.name),)}((Inf,))
+running_lower_boundaries(p::FlexibleParameter) = NamedTuple{(Symbol(p.name),)}((-Inf,))
 
 
 

--- a/src/io.jl
+++ b/src/io.jl
@@ -32,14 +32,19 @@ function deserialize(::Type{<:Running}, all_fields)
     Running(name), NamedTuple{(Symbol(name),)}((starting_value,))
 end
 
-serialize(c::FlexibleParameter; pars) =
-    LittleDict("type" => "FlexibleParameter", "name" => c.name, "starting_value" => value(c; pars), "fixed" => c.fixed)
+serialize(c::FlexibleParameter; pars) = LittleDict(
+    "type" => "FlexibleParameter",
+    "name" => c.name,
+    "starting_value" => value(c; pars),
+    "fixed" => c.fixed,
+)
 
 function deserialize(::Type{<:FlexibleParameter}, all_fields)
     name = all_fields["name"]
     starting_value = all_fields["starting_value"]
     fixed = get(all_fields, "fixed", false)
-    FlexibleParameter(name, starting_value, fixed), NamedTuple{(Symbol(name),)}((starting_value,))
+    FlexibleParameter(name, starting_value, fixed),
+    NamedTuple{(Symbol(name),)}((starting_value,))
 end
 
 

--- a/src/io.jl
+++ b/src/io.jl
@@ -1,7 +1,7 @@
 # parameter types
 register!(Fixed)
 register!(Running)
-register!(Parameter)
+register!(FlexibleParameter)
 register!(AdvancedParameter)
 
 # thin wrappers of primitives
@@ -30,6 +30,16 @@ function deserialize(::Type{<:Running}, all_fields)
     name = all_fields["name"]
     starting_value = all_fields["starting_value"]
     Running(name), NamedTuple{(Symbol(name),)}((starting_value,))
+end
+
+serialize(c::FlexibleParameter; pars) =
+    LittleDict("type" => "FlexibleParameter", "name" => c.name, "starting_value" => value(c; pars), "fixed" => c.fixed)
+
+function deserialize(::Type{<:FlexibleParameter}, all_fields)
+    name = all_fields["name"]
+    starting_value = all_fields["starting_value"]
+    fixed = get(all_fields, "fixed", false)
+    FlexibleParameter(name, starting_value, fixed), NamedTuple{(Symbol(name),)}((starting_value,))
 end
 
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -190,12 +190,14 @@ function generate_struct_fields(ordered_fields, param_type_params, parametric_ty
 
     # First pass: add parametric fields
     for field in ordered_fields
-        field_type(field) == :parametric && (parametric_idx = add_struct_field!(struct_fields, field, parametric_idx))
+        field_type(field) == :parametric &&
+            (parametric_idx = add_struct_field!(struct_fields, field, parametric_idx))
     end
 
     # Second pass: add parameter fields
     for field in ordered_fields
-        field_type(field) == :parameter && (param_idx = add_struct_field!(struct_fields, field, param_idx))
+        field_type(field) == :parameter &&
+            (param_idx = add_struct_field!(struct_fields, field, param_idx))
     end
 
     # Third pass: add constant fields
@@ -228,7 +230,12 @@ end
 
 # Multiple dispatch: Extract parameter from field (only for ParameterField)
 # Mutates param_extractions and param_names
-function extract_parameter!(param_extractions, param_names, field::ParameterField, value_ref)
+function extract_parameter!(
+    param_extractions,
+    param_names,
+    field::ParameterField,
+    value_ref,
+)
     field_name = Symbol("description_of_", field.name)
     push!(param_names, field.name)
     push!(
@@ -261,8 +268,10 @@ get_parameter_name(::ParametricField) = nothing
 get_parameter_name(::ConstantField) = nothing
 
 # Multiple dispatch: Count fields by type using dispatch
-count_field_type(::Type{ParameterField}, fields) = count(f -> field_type(f) == :parameter, fields)
-count_field_type(::Type{ParametricField}, fields) = count(f -> field_type(f) == :parametric, fields)
+count_field_type(::Type{ParameterField}, fields) =
+    count(f -> field_type(f) == :parameter, fields)
+count_field_type(::Type{ParametricField}, fields) =
+    count(f -> field_type(f) == :parametric, fields)
 
 # Helper: Generate build_model function
 function generate_build_model_function(constructor_name, ordered_fields, body, mod_name)
@@ -304,14 +313,16 @@ function parse_macro_arguments(model_name_expr, params_expr...)
     # Normalize input: handle both @with_parameters(ModelName; ...) and @with_parameters ModelName; ...
     # Julia parses these differently, so we need to handle both cases
     args_to_process = Any[]
-    
+
     if model_name_expr isa Expr && model_name_expr.head == :parameters
         # Syntax: @with_parameters(ModelName; fields...) - model name is in params_expr
         if !isempty(params_expr) && params_expr[1] isa Symbol
             model_name = params_expr[1]
             args_to_process = model_name_expr.args
         else
-            error("@with_parameters: model name missing. Expected: @with_parameters(ModelName; fields..., begin ... end)")
+            error(
+                "@with_parameters: model name missing. Expected: @with_parameters(ModelName; fields..., begin ... end)",
+            )
         end
     elseif model_name_expr isa Symbol
         # Syntax: @with_parameters ModelName; fields... - model name is first
@@ -336,7 +347,7 @@ function parse_macro_arguments(model_name_expr, params_expr...)
         if arg isa Expr && arg.head == :parameters
             for field_expr in arg.args
                 field_expr isa LineNumberNode && continue
-                
+
                 if is_body_block(field_expr)
                     body = extract_body_block(field_expr)
                     break
@@ -347,7 +358,7 @@ function parse_macro_arguments(model_name_expr, params_expr...)
             end
             # If body was found in parameters expression, stop processing
             body !== nothing && break
-        # Handle direct field declarations (no semicolon syntax)
+            # Handle direct field declarations (no semicolon syntax)
         elseif arg isa Symbol || (arg isa Expr && arg.head == :(::))
             field = parse_field(arg)
             push!(ordered_fields, field)
@@ -372,7 +383,8 @@ macro with_parameters(model_name_expr, params_expr...)
     mod_name = nameof(mod)
 
     # Parse arguments sequentially: model name, fields, and body
-    model_name, ordered_fields, body = parse_macro_arguments(model_name_expr, params_expr...)
+    model_name, ordered_fields, body =
+        parse_macro_arguments(model_name_expr, params_expr...)
 
     # Collect all declared field names and parameter names
     all_declared_fields = Set{Symbol}()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,8 +4,6 @@ using Distributions
 using NumericalDistributions
 using JSON
 
-import BuildConstructors: Parameter
-
 @testset "BuildConstructors tests" begin
     # let # to be replaced by the line above once working
     cCBpSECH_running_w = ConstructorOfCBpSECH(

--- a/test/test-parameter.jl
+++ b/test/test-parameter.jl
@@ -2,17 +2,15 @@ using BuildConstructors
 using ComponentArrays
 using Test
 
-import BuildConstructors: Parameter
-
 constructor = ConstructorOfPRBModel(
-    ConstructorOfBW(Parameter("m", 2.0), Parameter("Γ", 0.2), (1.0, 2.5)),
+    ConstructorOfBW(FlexibleParameter("m", 2.0), FlexibleParameter("Γ", 0.2), (1.0, 2.5)),
     ConstructorOfGaussian(Fixed(0.0), Running("σ"), (-0.5, 0.5)),
-    ConstructorOfPol1(Parameter("c1", 0.3), (1.0, 2.5)),
+    ConstructorOfPol1(FlexibleParameter("c1", 0.3), (1.0, 2.5)),
     AdvancedParameter("fs", 0.5; boundaries = (0.0, 1.0), uncertainty = 0.01),
     (1.0, 2.5),
 )
 
-@testset "Parameter is mutable" begin
+@testset "FlexibleParameter is mutable" begin
     @test constructor.model_p.description_of_m.fixed == false
     setfield!(constructor.model_p.description_of_m, :fixed, true)
     @test getfield(constructor.model_p.description_of_m, :fixed) == true
@@ -90,7 +88,7 @@ end
     @test running_uncertainties(f) == NamedTuple()
 
     # Test on constructor - should collect from all fields
-    # The constructor has: Parameter("m"), Parameter("Γ"), Fixed(0.0), Running("σ"), Parameter("c1"), Parameter("fs")
+    # The constructor has: FlexibleParameter("m"), FlexibleParameter("Γ"), Fixed(0.0), Running("σ"), FlexibleParameter("c1"), FlexibleParameter("fs")
     # Only Running("σ") should contribute
     @test running_uncertainties(constructor) ===
           (m = missing, Γ = missing, σ = missing, c1 = missing, fs = 0.01)
@@ -98,8 +96,8 @@ end
 end
 
 @testset "running_upper_boundaries" begin
-    # Test on individual Parameter
-    p = Parameter("test", 1.0)
+    # Test on individual FlexibleParameter
+    p = FlexibleParameter("test", 1.0)
     @test running_upper_boundaries(p) == (test = Inf,)
 
     # Test on Running
@@ -111,8 +109,8 @@ end
     @test running_upper_boundaries(f) == NamedTuple()
 
     # Test on constructor - should collect from all fields
-    # The constructor has: Parameter("m"), Parameter("Γ"), Fixed(0.0), Running("σ"), Parameter("c1"), Parameter("fs")
-    # All Parameters and Running should contribute with Inf
+    # The constructor has: FlexibleParameter("m"), FlexibleParameter("Γ"), Fixed(0.0), Running("σ"), FlexibleParameter("c1"), FlexibleParameter("fs")
+    # All FlexibleParameters and Running should contribute with Inf
     upper_bounds = running_upper_boundaries(constructor)
     @test keys(upper_bounds) == keys(running_values(constructor))
     @test upper_bounds.m == Inf
@@ -124,8 +122,8 @@ end
 end
 
 @testset "running_lower_boundaries" begin
-    # Test on individual Parameter
-    p = Parameter("test", 1.0)
+    # Test on individual FlexibleParameter
+    p = FlexibleParameter("test", 1.0)
     @test running_lower_boundaries(p) == (test = -Inf,)
 
     # Test on Running
@@ -137,8 +135,8 @@ end
     @test running_lower_boundaries(f) == NamedTuple()
 
     # Test on constructor - should collect from all fields
-    # The constructor has: Parameter("m"), Parameter("Γ"), Fixed(0.0), Running("σ"), Parameter("c1"), Parameter("fs")
-    # All Parameters and Running should contribute with -Inf
+    # The constructor has: FlexibleParameter("m"), FlexibleParameter("Γ"), Fixed(0.0), Running("σ"), FlexibleParameter("c1"), FlexibleParameter("fs")
+    # All FlexibleParameters and Running should contribute with -Inf
     lower_bounds = running_lower_boundaries(constructor)
     @test keys(lower_bounds) == keys(running_values(constructor))
     @test lower_bounds.m == -Inf


### PR DESCRIPTION
Renames the `Parameter` type to `FlexibleParameter` throughout the codebase and exports it.
The more specific name avoids conflicts and makes the type exportable, so users can use `FlexibleParameter` directly without `import BuildConstructors: Parameter`.

**Changes:**
- Renamed `Parameter` → `FlexibleParameter` in all source and test files
- Added `FlexibleParameter` to module exports (no explicit import needed)
- Added `serialize`/`deserialize` methods for `FlexibleParameter`
- Updated all test files to use the new name

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/mmikhasenko/HadronicLineshapes.jl/blob/main/docs/src/90-contributing.md)

- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
