### PR TITLE
fix value call, add example1

### DIFF
--- a/docs/example1.jl
+++ b/docs/example1.jl
@@ -1,0 +1,55 @@
+using NumericalDistributions
+using HadronicLineshapes
+using BuildConstructors
+using Distributions
+using Plots
+
+theme(:boxed)
+
+# instructions how to use parameters in 
+# building flexible models
+@with_parameters(Gauss; μ::P, σ::P, begin Normal(μ, σ) end)
+@with_parameters(NormalizeAbs2Abs2; D, support::Tuple{Float64,Float64},
+    begin
+        NumericallyIntegrable(e->abs2(build_model(_.D, pars)(e^2)), _.support)
+    end)
+@with_parameters(BW; m::P, Γ::P, begin BreitWigner(m, Γ) end)
+@with_parameters(Cut; cModel, support::Tuple{Float64,Float64}, begin truncated(build_model(_.cModel, pars), _.support[1], _.support[2]) end)
+@with_parameters(S; cModel, scale::P, begin build_model(_.cModel, pars) * scale end)
+@with_parameters(Comb; 
+    cModel1,
+    cModel2, 
+    weight::P,
+    begin
+        MixtureModel([build_model(_.cModel1, pars), build_model(_.cModel2, pars)], [weight, 1-weight])
+    end
+)
+
+
+# Let's try how it works
+c = ConstructorOfComb(
+    ConstructorOfCut(
+            ConstructorOfS(
+                ConstructorOfGauss(Running("μ"), Fixed(1.0)),
+                Running("scale"),
+            ),
+            (0.5, 2.5),
+    ),
+    ConstructorOfNormalizeAbs2Abs2(
+        ConstructorOfBW(Running("m"), Fixed(0.1)),
+        (0.5, 2.5)
+    ),
+    Running("weight"),
+)
+
+# let's see what parameters are running, if there are good default values
+running_values(c)
+
+# build a model and plot it
+m = build_model(c, (μ = 1.2, scale = 0.7, m = 1.8718, weight = 0.5))
+let
+    plot(x->pdf(m,x), 0.5, 2.5)
+    plot!(x->pdf(m.components[1],x) * m.prior.p[1], 0.5, 2.5)
+    plot!(x->pdf(m.components[2],x) * m.prior.p[2], 0.5, 2.5)
+end
+

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -274,8 +274,8 @@ count_field_type(::Type{ParametricField}, fields) =
     count(f -> field_type(f) == :parametric, fields)
 
 # Helper: Generate build_model function
-function generate_build_model_function(constructor_name, ordered_fields, body, mod_name)
-    value_ref = Expr(:., mod_name, QuoteNode(:value))
+function generate_build_model_function(constructor_name, ordered_fields, body)
+    value_ref = Expr(:., :BuildConstructors, QuoteNode(:value))
 
     # Extract parameters: param = value(c.description_of_{param}; pars)
     param_extractions = Expr(:block)
@@ -379,9 +379,6 @@ function parse_macro_arguments(model_name_expr, params_expr...)
 end
 
 macro with_parameters(model_name_expr, params_expr...)
-    mod = __module__
-    mod_name = nameof(mod)
-
     # Parse arguments sequentially: model name, fields, and body
     model_name, ordered_fields, body =
         parse_macro_arguments(model_name_expr, params_expr...)
@@ -428,7 +425,7 @@ macro with_parameters(model_name_expr, params_expr...)
         struct_fields,
     )
     build_model_def =
-        generate_build_model_function(constructor_name, ordered_fields, body, mod_name)
+        generate_build_model_function(constructor_name, ordered_fields, body)
 
     return Expr(:block, esc(struct_def), esc(build_model_def), Expr(:line, __source__))
 end

--- a/test/test-macro.jl
+++ b/test/test-macro.jl
@@ -3,9 +3,6 @@ using BuildConstructors
 using Distributions
 using Test
 
-# Import types and functions needed for macro expansion
-import BuildConstructors: AbstractParameter, AbstractConstructor, value, build_model
-
 # Test Case 1: Simple 2-parameter model (Gaussian)
 # This should generate the same as the manual ConstructorOfGaussian
 @with_parameters(


### PR DESCRIPTION
When building example, I realized that `value` was called with prefix `Main.value`, which is wrong.

It only worked in tests because
```
import BuildConstructors: AbstractParameter, AbstractConstructor, value, build_model
```
removing it.


## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/mmikhasenko/HadronicLineshapes.jl/blob/main/docs/src/90-contributing.md)

- [ ] Tests are passing
- [ ] Lint workflow is passing
- [ ] Docs were updated and workflow is passing
