### PR TITLE
[codex] Clarify constructor pattern documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,102 +1,254 @@
-# PRB Model Construction Framework
+# BuildConstructors.jl
 
-This repository provides a modular system for constructing composite probability models of the general **Physical ⨂ Resolution + Background** form:
+`BuildConstructors.jl` is a small pattern for building Julia objects whose numerical
+parameters need extra metadata: defaults, fixed/free state, bounds, uncertainties,
+or names used by a fitting backend.
 
+Trying to attach that metadata directly to user objects usually hits a wall. Some
+objects are immutable, some come from another package, some have no natural place
+for a default value, and some are not even parameterized in the way your workflow
+needs. The part that always works is to wrap the object construction instead:
 
-The framework is designed so that each model component is represented by a **constructor object**. These constructors do *not* contain numerical values directly; instead, they hold parameter descriptors that tell the system whether a parameter is:
+1. Store parameter descriptors in a constructor object.
+2. Collect or update the running parameters from that constructor.
+3. Call `build_model(constructor, pars)` to create the real object.
 
-| Parameter Type | Meaning | Example Usage |
-|----------------|---------|----------------|
-| `Fixed(value)` | Constant, does not vary in fits | `Fixed(0.1)` |
-| `Running(name)` | Free parameter controlled during fitting | `Running("g")` |
+The wrapped object can be anything: a distribution, a model, a callable, a nested
+composition, or a domain-specific type from another package. `BuildConstructors.jl`
+does not impose a dimensionality, a call signature, or a model interface. Those
+choices stay with you.
 
-Running parameters are automatically collected into a `NamedTuple` during deserialization and passed to model evaluation functions during fitting.
+## Essential vs Optional
 
----
+The essential pattern is small:
 
-## Core Concepts
+1. Use parameter descriptors such as `Fixed`, `Running`, or your own
+   `AbstractParameter` subtype.
+2. Store those descriptors in an `AbstractConstructor`.
+3. Implement `build_model(constructor, pars)`.
 
-### Parameter Representation
+Everything else is convenience:
 
-```julia
-struct Fixed <: AbstractParameter
-    value::Float64
-end
+| Layer | Essential? | Why it exists |
+| --- | --- | --- |
+| `Fixed`, `Running`, `FlexibleParameter`, `AdvancedParameter` | Useful defaults | Common descriptor types for fixed/free parameters, defaults, bounds, and uncertainties. |
+| `running_values`, `fix!`, `release!`, `update!` | Convenience | Recursive tools for collecting and mutating metadata in nested constructors. |
+| `@with_parameters` | Convenience | Removes boilerplate when a constructor mostly maps parameter descriptors into a `build_model` body. |
+| `serialize` / `deserialize` / `register!` | Optional | Save and restore constructor descriptions through JSON or database-like workflows. |
+| PRB model constructors and loaders | Optional example | Domain-specific probability-model utilities built with the same general mechanism. |
 
-struct Running <: AbstractParameter
-    name::String
-end
+If your object already has a perfect home for metadata, you may not need this
+package. It becomes useful when the object should remain clean, external,
+immutable, or domain-native, but your workflow still needs to know which numbers
+are fixed, running, bounded, initialized, or serializable.
 
-# Numerical values are accessed uniformly:
+## Basic Idea
 
-value(p::Fixed; pars) = p.value
-value(p::Running; pars) = getproperty(pars, Symbol(p.name))
-```
-
----
-
-### Complete models used in fits are assembled via:
-
-```julia
-struct ConstructorOfPRBModel{PHYS,RES,BG,T}
-    model_p::PHYS       # Physical model component
-    model_r::RES        # Resolution model component
-    model_b::BG         # Background model component
-    description_of_fs::T
-    support::Tuple{Float64,Float64}   # Fit range
-end
-
-# The model is then called by:
-
-model = build_model(constructor, parameter_values)
-```
----
-## Adding a New Model
-
-To implement a new model (physical, resolution, or background), define a `struct`, `build_model` function, `deserialize` and `serialize` methods:
+Parameters are represented by small descriptor objects. A descriptor decides how a
+numerical value is obtained when the real model is built.
 
 ```julia
-struct ConstructorOfMyModel{T1<:AbstractParameter,T2<:AbstractParameter}
-    description_of_a::T1
-    description_of_b::T2
-    support::Tuple{Float64,Float64}
-end
+using BuildConstructors
 
-function build_model(c::ConstructorOfMyModel, pars)
-    a = value(c.description_of_a; pars)
-    b = value(c.description_of_b; pars)
-    # return model object here
-end
-
-function deserialize(::Type{<:ConstructorOfMyModel}, all_fields)
-    appendix = NamedTuple()
-    
-    desc_a_dict = all_fields["description_of_a"]
-    type_a = _type_from_string(desc_a_dict["type"])
-    desc_a, app_a = deserialize(type_a, desc_a_dict)
-    appendix = merge(appendix, app_a)
-    
-    desc_b_dict = all_fields["description_of_b"]
-    type_b = _type_from_string(desc_b_dict["type"])
-    desc_b, app_b = deserialize(type_b, desc_b_dict)
-    appendix = merge(appendix, app_b)
-    
-    support = all_fields["support"] |> Tuple
-    return ConstructorOfMyModel(desc_a, desc_b, support), appendix
-end
-
-serialize(c::ConstructorOfMyModel; pars) = LittleDict(
-    "type" => "ConstructorOfMyModel",
-    "description_of_a" => serialize(c.description_of_a; pars),
-    "description_of_b" => serialize(c.description_of_b; pars),
-    "support" => c.support
-)
+Fixed(1.0)        # always evaluates to 1.0
+Running("scale")  # reads `scale` from the supplied parameter values
 ```
 
-**Note:** If you define custom types for parameter or model constructors, you must register them using `BuildConstructors.register!(TypeName)` so they can be properly deserialized.
+A constructor stores these descriptors instead of storing the numerical values
+directly:
 
+```julia
+using Distributions
 
+struct ConstructorOfNormalModel{T1<:BuildConstructors.AbstractParameter,
+                                T2<:BuildConstructors.AbstractParameter} <:
+       BuildConstructors.AbstractConstructor
+    description_of_μ::T1
+    description_of_σ::T2
+end
 
+function BuildConstructors.build_model(c::ConstructorOfNormalModel, pars)
+    μ = BuildConstructors.value(c.description_of_μ; pars)
+    σ = BuildConstructors.value(c.description_of_σ; pars)
+    return Normal(μ, σ)
+end
 
+c = ConstructorOfNormalModel(Fixed(0.0), Running("σ"))
 
+running_values(c)        # (σ = missing,)
+model = build_model(c, (σ = 0.2,))
+```
 
+This keeps the user object clean. `Normal(0.0, 0.2)` does not need to know that
+`σ` was called `"σ"`, was free in a fit, had a starting value, or came from a JSON
+file. The constructor knows that, and the final object stays exactly the object you
+wanted to build.
+
+## Parameter Descriptors
+
+The package includes a few ready-to-use descriptors:
+
+| Descriptor | Use |
+| --- | --- |
+| `Fixed(value)` | A constant value that is not collected as a running parameter. |
+| `Running(name)` | A free parameter read from `pars` by name. |
+| `FlexibleParameter(name, value)` | A parameter with a stored value that can be fixed or released. |
+| `AdvancedParameter(name, value; boundaries, uncertainty)` | A parameter with a stored value, bounds, uncertainty, and fixed/free state. |
+
+The same generic tools work recursively on constructors and nested constructors:
+
+```julia
+running_values(c)
+running_uncertainties(c)
+running_lower_boundaries(c)
+running_upper_boundaries(c)
+
+fix!(c, (:σ,))
+release!(c, (:σ,))
+update!(c, (σ = 0.25,))
+```
+
+You can define your own parameter descriptor by subtyping
+`BuildConstructors.AbstractParameter` and implementing `BuildConstructors.value`.
+Implement the other methods only if your descriptor needs to participate in fixing,
+releasing, updating, or collection of metadata.
+
+## The `build_model` Convention
+
+The main convention is:
+
+```julia
+build_model(constructor, pars)
+```
+
+`pars` is deliberately unconstrained. It can be a `NamedTuple`, a
+`ComponentArray`, or any object your parameter descriptors know how to read.
+Likewise, `build_model` can return any Julia object. This is the central design
+choice of the package: the constructor carries metadata and assembly logic, while
+your returned object remains domain-native.
+
+Nested construction is just ordinary Julia:
+
+```julia
+struct ConstructorOfScaled{C,T<:BuildConstructors.AbstractParameter} <:
+       BuildConstructors.AbstractConstructor
+    child::C
+    description_of_scale::T
+end
+
+function BuildConstructors.build_model(c::ConstructorOfScaled, pars)
+    child = build_model(c.child, pars)
+    scale = BuildConstructors.value(c.description_of_scale; pars)
+    return x -> scale * child(x)
+end
+```
+
+Because the metadata collection methods walk over fields of
+`AbstractConstructor`s, running parameters inside `child` are collected together
+with `scale`.
+
+## Less Boilerplate With `@with_parameters`
+
+For many simple wrappers, the `@with_parameters` macro generates the constructor
+type and `build_model` method for you:
+
+```julia
+using BuildConstructors
+using Distributions
+
+@with_parameters(Gauss; μ::P, σ::P, begin
+    Normal(μ, σ)
+end)
+
+c = ConstructorOfGauss(Fixed(0.0), Running("σ"))
+model = build_model(c, (σ = 0.2,))
+```
+
+The macro call has three parts:
+
+1. The model name, `Gauss`.
+2. A field list after the semicolon.
+3. A `begin ... end` body that returns the final object.
+
+The generated type is named `ConstructorOf{Name}`. For `Gauss`, the macro creates
+`ConstructorOfGauss` and a method equivalent to
+`build_model(c::ConstructorOfGauss, pars)`.
+
+Field declarations have three forms, and the distinction is important:
+
+| Form | Meaning |
+| --- | --- |
+| `field::P` | A parameter descriptor field, available in the body as the resolved value `field`. |
+| `field::SomeType` | A constant field, accessed in the body as `_.field`. |
+| `field` | A parametric field, useful for nested constructors, accessed as `_.field`. |
+
+For `field::P`, the generated struct field is named `description_of_field`.
+This keeps the constructor honest: it stores the parameter description, not the
+current numeric value. During `build_model`, the macro inserts:
+
+```julia
+field = BuildConstructors.value(c.description_of_field; pars)
+```
+
+For `field::SomeType` and plain `field`, the value is stored directly in the
+constructor. In the body, those fields must be accessed through `_`, as in
+`_.support` or `_.child`. Direct access is rejected by the macro so that parameter
+values and constructor fields do not get mixed up silently.
+
+For example:
+
+```julia
+@with_parameters(Scaled; child, scale::P, begin
+    child_model = build_model(_.child, pars)
+    x -> scale * child_model(x)
+end)
+```
+
+Here `child` can be another constructor, a callable, or any user object. `scale`
+is a parameter descriptor, so the generated constructor is called as:
+
+```julia
+c = ConstructorOfScaled(child_constructor, Running("scale"))
+```
+
+The generated field order is stable: plain parametric fields first, parameter
+descriptor fields second, and typed constant fields last. That means a mixed
+declaration such as:
+
+```julia
+@with_parameters(Windowed; model, μ::P, support::Tuple{Float64,Float64}, begin
+    truncated(build_model(_.model, pars), _.support[1] + μ, _.support[2] + μ)
+end)
+```
+
+is constructed as:
+
+```julia
+ConstructorOfWindowed(model, μ_descriptor, support)
+```
+
+Use the macro when that generated shape is clear and useful. Write the constructor
+and `build_model` by hand when you need a custom field order, extra validation,
+special constructors, or a more explicit API.
+
+## Serialization
+
+Serialization is useful when constructor descriptions need to move through files,
+databases, or fitting pipelines. The package provides `serialize` and `deserialize`
+methods for its built-in descriptors and included example constructors. Custom
+types can participate by defining their own methods and registering the type:
+
+```julia
+BuildConstructors.register!(ConstructorOfMyModel)
+```
+
+Serialization is a bonus layer on top of the core pattern. You can use
+constructors, parameter collection, `fix!`, `release!`, `update!`, and
+`build_model` without using JSON at all.
+
+## Included Examples
+
+The repository includes several constructors for probability-model workflows,
+including the physical-resolution-background composition used in the original
+application. They are examples of the same general mechanism rather than a
+restriction on what the package can build.

--- a/src/abstract-constructor.jl
+++ b/src/abstract-constructor.jl
@@ -1,7 +1,28 @@
+"""
+    AbstractConstructor
+
+Abstract supertype for objects that describe how to build another Julia object.
+
+Subtypes usually store parameter descriptors and any non-parameter configuration
+needed by `build_model`. Generic metadata utilities such as `running_values`,
+`fix!`, `release!`, and `update!` recurse through fields of
+`AbstractConstructor`s, so nested constructors compose naturally.
+"""
 abstract type AbstractConstructor end
 
+"""
+    build_model(constructor::AbstractConstructor, pars)
+
+Build the domain object described by `constructor` using parameter values from
+`pars`.
+
+`BuildConstructors.jl` deliberately does not constrain either argument beyond this
+convention: `pars` can be a `NamedTuple`, `ComponentArray`, or any object your
+parameter descriptors understand, and the return value can be any Julia object.
+Implement this method for each constructor type you define.
+"""
 build_model(c::AbstractConstructor, pars) =
-    error("`build_model` not implemented for $(typeof(c)). You need to define a `build_mode(c::ConstructorOfYourModel, pars) -> YourModel` function for your constructor.")
+    error("`build_model` not implemented for $(typeof(c)). You need to define a `build_model(c::ConstructorOfYourModel, pars) -> YourModel` function for your constructor.")
 
 # for all constructors, apply the function to all fields
 for func in (:fix!, :release!, :update!)

--- a/src/abstract-parameters.jl
+++ b/src/abstract-parameters.jl
@@ -1,3 +1,14 @@
+"""
+    AbstractParameter
+
+Abstract supertype for parameter descriptors.
+
+A parameter descriptor is metadata about a numeric value, not necessarily the
+numeric value itself. Subtypes should implement `BuildConstructors.value(p; pars)`
+to define how the number is obtained when a constructor is built. They may also
+implement `fix!`, `release!`, `update!`, and the `running_*` collectors when they
+carry fixed/free state, defaults, bounds, or uncertainties.
+"""
 abstract type AbstractParameter end
 
 # Any parameter realization, needs to implement the following functions:

--- a/src/concrete-parameters.jl
+++ b/src/concrete-parameters.jl
@@ -130,9 +130,11 @@ release!(p::FlexibleParameter, par_names) =
 
 Replace the stored value with `pars[p.name]` when that name is present.
 """
-update!(c::FlexibleParameter, pars) =
-    Symbol(c.name) ∈ keys(pars) ? setfield!(c, :value, getproperty(pars, Symbol(c.name))) :
-    nothing
+function update!(c::FlexibleParameter, pars)
+    sym = Symbol(c.name)
+    hasproperty(pars, sym) && (c.value = getproperty(pars, sym))
+    return nothing
+end
 
 """
     running_values(p::FlexibleParameter)
@@ -222,9 +224,11 @@ release!(p::AdvancedParameter, par_names) =
 
 Replace the stored value with `pars[p.name]` when that name is present.
 """
-update!(c::AdvancedParameter, pars) =
-    Symbol(c.name) ∈ keys(pars) ? setfield!(c, :value, getproperty(pars, Symbol(c.name))) :
-    nothing
+function update!(c::AdvancedParameter, pars)
+    sym = Symbol(c.name)
+    hasproperty(pars, sym) && (c.value = getproperty(pars, sym))
+    return nothing
+end
 
 """
     running_values(p::AdvancedParameter)

--- a/src/concrete-parameters.jl
+++ b/src/concrete-parameters.jl
@@ -167,7 +167,7 @@ running_lower_boundaries(p::FlexibleParameter) = NamedTuple{(Symbol(p.name),)}((
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # advanced parameter, can be fixed and released, and has boundaries and uncertainty
 """
-    AdvancedParameter(name, value; boundaries = (Inf, -Inf), uncertainty = 1.0)
+    AdvancedParameter(name, value; boundaries = (-Inf, Inf), uncertainty = 1.0)
     AdvancedParameter(name, value, boundaries, uncertainty, fixed)
 
 Mutable parameter descriptor with stored value, bounds, uncertainty, and
@@ -194,11 +194,11 @@ Resolve to the stored value when `p.fixed` is true; otherwise read `p.name` from
 value(p::AdvancedParameter; pars) = p.fixed ? p.value : getproperty(pars, Symbol(p.name))
 
 """
-    AdvancedParameter(name, value; boundaries = (Inf, -Inf), uncertainty = 1.0)
+    AdvancedParameter(name, value; boundaries = (-Inf, Inf), uncertainty = 1.0)
 
 Create a free `AdvancedParameter` with stored value, bounds, and uncertainty.
 """
-AdvancedParameter(name, value; boundaries = (Inf, -Inf), uncertainty = 1.0) =
+AdvancedParameter(name, value; boundaries = (-Inf, Inf), uncertainty = 1.0) =
     AdvancedParameter(name, value, boundaries, uncertainty, false)
 
 """

--- a/src/concrete-parameters.jl
+++ b/src/concrete-parameters.jl
@@ -1,53 +1,182 @@
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # very simple parameters
+"""
+    Fixed(value)
+
+Parameter descriptor that always resolves to the stored numeric `value`.
+
+`Fixed` parameters are intentionally absent from `running_values` and related
+metadata collectors, because they are not expected to be supplied by a fitting or
+optimization backend.
+"""
 struct Fixed <: AbstractParameter
     value::Float64
 end
 
+"""
+    value(parameter; pars)
+
+Resolve a parameter descriptor to the numeric value used by `build_model`.
+
+Built-in descriptors either ignore `pars` (`Fixed`) or read a value from it
+(`Running`, `FlexibleParameter`, `AdvancedParameter`). Custom descriptors should
+implement this method when introducing a new way to obtain parameter values.
+"""
 value(p::Fixed; pars) = p.value
 # other methods are default -- nothing
 
 
+"""
+    Running(name)
+
+Parameter descriptor for a free parameter read from `pars` by name.
+
+For example, `Running("σ")` resolves with `getproperty(pars, :σ)`. It is collected
+by `running_values` with a `missing` value, signalling that no default is stored
+inside the descriptor.
+"""
 struct Running <: AbstractParameter
     name::String
 end
 
+"""
+    value(p::Running; pars)
+
+Resolve a running parameter by reading `Symbol(p.name)` from `pars`.
+"""
 value(p::Running; pars) = getproperty(pars, Symbol(p.name))
+
+"""
+    running_values(p::Running)
+
+Return a one-entry `NamedTuple` for the running parameter name, with `missing` as
+the value because `Running` stores no default.
+"""
 running_values(c::Running) = NamedTuple{(Symbol(c.name),)}((missing,))
+
+"""
+    running_uncertainties(p::Running)
+
+Return `missing` uncertainty metadata for a plain `Running` parameter.
+"""
 running_uncertainties(p::Running) = NamedTuple{(Symbol(p.name),)}((missing,))
+
+"""
+    running_upper_boundaries(p::Running)
+
+Return `Inf` as the default upper boundary for a plain `Running` parameter.
+"""
 running_upper_boundaries(c::Running) = NamedTuple{(Symbol(c.name),)}((Inf,))
+
+"""
+    running_lower_boundaries(p::Running)
+
+Return `-Inf` as the default lower boundary for a plain `Running` parameter.
+"""
 running_lower_boundaries(c::Running) = NamedTuple{(Symbol(c.name),)}((-Inf,))
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # mutable parameter, can be fixed and released
+"""
+    FlexibleParameter(name, value[, fixed])
+
+Mutable parameter descriptor with a stored value and fixed/free state.
+
+When free, it resolves from `pars` just like `Running`. When fixed, it resolves to
+its stored value. Use `fix!`, `release!`, and `update!` to mutate the state and
+stored value in-place.
+"""
 mutable struct FlexibleParameter <: AbstractParameter
     name::String
     value::Float64
     fixed::Bool
 end
+
+"""
+    value(p::FlexibleParameter; pars)
+
+Resolve to the stored value when `p.fixed` is true; otherwise read `p.name` from
+`pars`.
+"""
 value(p::FlexibleParameter; pars) = p.fixed ? p.value : getproperty(pars, Symbol(p.name))
+
+"""
+    FlexibleParameter(name, value)
+
+Create a free `FlexibleParameter` with a stored starting value.
+"""
 FlexibleParameter(name, value) = FlexibleParameter(name, value, false)
 
+"""
+    fix!(p::FlexibleParameter, par_names)
+
+Set `p.fixed = true` when `Symbol(p.name)` is present in `par_names`.
+"""
 fix!(p::FlexibleParameter, par_names) =
     Symbol(p.name) ∈ par_names ? setfield!(p, :fixed, true) : nothing
+
+"""
+    release!(p::FlexibleParameter, par_names)
+
+Set `p.fixed = false` when `Symbol(p.name)` is present in `par_names`.
+"""
 release!(p::FlexibleParameter, par_names) =
     Symbol(p.name) ∈ par_names ? setfield!(p, :fixed, false) : nothing
 
+"""
+    update!(p::FlexibleParameter, pars)
+
+Replace the stored value with `pars[p.name]` when that name is present.
+"""
 update!(c::FlexibleParameter, pars) =
     Symbol(c.name) ∈ keys(pars) ? setfield!(c, :value, getproperty(pars, Symbol(c.name))) :
     nothing
 
+"""
+    running_values(p::FlexibleParameter)
+
+Return the stored value for this parameter, whether it is currently fixed or free.
+"""
 running_values(c::FlexibleParameter) = NamedTuple{(Symbol(c.name),)}((c.value,))
+
+"""
+    running_uncertainties(p::FlexibleParameter)
+
+Return `missing` uncertainty metadata for a flexible parameter.
+"""
 running_uncertainties(p::FlexibleParameter) = NamedTuple{(Symbol(p.name),)}((missing,))
+
+"""
+    running_upper_boundaries(p::FlexibleParameter)
+
+Return `Inf` as the default upper boundary for a flexible parameter.
+"""
 running_upper_boundaries(p::FlexibleParameter) = NamedTuple{(Symbol(p.name),)}((Inf,))
+
+"""
+    running_lower_boundaries(p::FlexibleParameter)
+
+Return `-Inf` as the default lower boundary for a flexible parameter.
+"""
 running_lower_boundaries(p::FlexibleParameter) = NamedTuple{(Symbol(p.name),)}((-Inf,))
 
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # advanced parameter, can be fixed and released, and has boundaries and uncertainty
+"""
+    AdvancedParameter(name, value; boundaries = (Inf, -Inf), uncertainty = 1.0)
+    AdvancedParameter(name, value, boundaries, uncertainty, fixed)
+
+Mutable parameter descriptor with stored value, bounds, uncertainty, and
+fixed/free state.
+
+Like `FlexibleParameter`, it resolves from `pars` while free and from its stored
+value while fixed. The extra metadata is returned by the corresponding
+`running_*` collection functions.
+"""
 mutable struct AdvancedParameter <: AbstractParameter
     name::String
     value::Float64
@@ -55,24 +184,75 @@ mutable struct AdvancedParameter <: AbstractParameter
     uncertainty::Float64
     fixed::Bool
 end
+
+"""
+    value(p::AdvancedParameter; pars)
+
+Resolve to the stored value when `p.fixed` is true; otherwise read `p.name` from
+`pars`.
+"""
 value(p::AdvancedParameter; pars) = p.fixed ? p.value : getproperty(pars, Symbol(p.name))
+
+"""
+    AdvancedParameter(name, value; boundaries = (Inf, -Inf), uncertainty = 1.0)
+
+Create a free `AdvancedParameter` with stored value, bounds, and uncertainty.
+"""
 AdvancedParameter(name, value; boundaries = (Inf, -Inf), uncertainty = 1.0) =
     AdvancedParameter(name, value, boundaries, uncertainty, false)
 
+"""
+    fix!(p::AdvancedParameter, par_names)
+
+Set `p.fixed = true` when `Symbol(p.name)` is present in `par_names`.
+"""
 fix!(p::AdvancedParameter, par_names) =
     Symbol(p.name) ∈ par_names ? setfield!(p, :fixed, true) : nothing
 
+"""
+    release!(p::AdvancedParameter, par_names)
+
+Set `p.fixed = false` when `Symbol(p.name)` is present in `par_names`.
+"""
 release!(p::AdvancedParameter, par_names) =
     Symbol(p.name) ∈ par_names ? setfield!(p, :fixed, false) : nothing
 
+"""
+    update!(p::AdvancedParameter, pars)
+
+Replace the stored value with `pars[p.name]` when that name is present.
+"""
 update!(c::AdvancedParameter, pars) =
     Symbol(c.name) ∈ keys(pars) ? setfield!(c, :value, getproperty(pars, Symbol(c.name))) :
     nothing
 
+"""
+    running_values(p::AdvancedParameter)
+
+Return the stored value for this parameter.
+"""
 running_values(c::AdvancedParameter) = NamedTuple{(Symbol(c.name),)}((c.value,))
+
+"""
+    running_uncertainties(p::AdvancedParameter)
+
+Return the stored uncertainty for this parameter.
+"""
 running_uncertainties(p::AdvancedParameter) =
     NamedTuple{(Symbol(p.name),)}((p.uncertainty,))
+
+"""
+    running_upper_boundaries(p::AdvancedParameter)
+
+Return the upper boundary stored in `p.boundaries[2]`.
+"""
 running_upper_boundaries(p::AdvancedParameter) =
     NamedTuple{(Symbol(p.name),)}((p.boundaries[2],))
+
+"""
+    running_lower_boundaries(p::AdvancedParameter)
+
+Return the lower boundary stored in `p.boundaries[1]`.
+"""
 running_lower_boundaries(p::AdvancedParameter) =
     NamedTuple{(Symbol(p.name),)}((p.boundaries[1],))

--- a/src/io.jl
+++ b/src/io.jl
@@ -17,10 +17,29 @@ register!(ConstructorOfPRBModel)
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # 
 
+"""
+    serialize(constructor_or_parameter; pars)
+
+Convert a parameter descriptor or constructor into a dictionary-like object.
+
+For running parameters, `pars` supplies the current numerical values that should be
+stored as starting values. Serialization is optional: the core constructor pattern
+works without it, but these methods are useful when constructor descriptions need
+to be saved to JSON or a database.
+"""
 serialize(c::Fixed; pars) = LittleDict("type" => "Fixed", "value" => c.value)
 serialize(c::Running; pars) =
     LittleDict("type" => "Running", "name" => c.name, "starting_value" => value(c; pars))
 
+"""
+    deserialize(::Type{T}, all_fields) -> constructor_or_parameter, starting_parameters
+
+Rebuild a parameter descriptor or constructor from serialized fields.
+
+The second return value is a `NamedTuple` of starting values collected while
+deserializing running parameters. Custom serializable types should implement this
+method and call `register!(T)` so type names can be resolved from serialized data.
+"""
 function deserialize(::Type{<:Fixed}, all_fields)
     value = all_fields["value"]
     Fixed(value), NamedTuple()

--- a/src/load-model-from-json.jl
+++ b/src/load-model-from-json.jl
@@ -2,6 +2,16 @@
 
 using JSON, OrderedCollections
 
+"""
+    convert_database_to_prb(db, phys, res, bg)
+
+Convert a database-style PRB entry into the serialized
+`ConstructorOfPRBModel` shape expected by `deserialize`.
+
+This is a domain-specific convenience for the included
+physical-resolution-background examples. It is not required for general
+`BuildConstructors.jl` usage.
+"""
 function convert_database_to_prb(db, phys, res, bg)
     # pick components
     model_p = db["physical"][phys]
@@ -28,6 +38,16 @@ function convert_database_to_prb(db, phys, res, bg)
     )
 end
 
+"""
+    load_prb_model_from_json(filename, phys, res, bg) -> constructor, starting_parameters
+
+Load a physical-resolution-background constructor from a JSON database file.
+
+The returned constructor can be passed to `build_model(constructor,
+starting_parameters)` or updated with another parameter container. This function
+is an optional helper for the bundled PRB workflow rather than part of the minimal
+constructor pattern.
+"""
 function load_prb_model_from_json(filename, phys, res, bg)
     db = JSON.parsefile(filename; dicttype = OrderedDict)
     converted = convert_database_to_prb(db, phys, res, bg)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1,25 +1,41 @@
 """
-    @with_parameters ModelName; field1, field2::P, field3::Type, ... begin
-        # model-building logic
+    @with_parameters ModelName; fields... begin
+        body
     end
 
-Generate a constructor struct and build_model function for a model with the given fields.
+Generate a `ConstructorOfModelName` subtype of `AbstractConstructor` and a
+matching `build_model(::ConstructorOfModelName, pars)` method.
 
-Fields can be of three types:
-1. `field` (no type) → parametric field (type parameter P1, P2, ...)
-2. `field::P` → parameter field (becomes `description_of_field::T1<:AbstractParameter`)
-3. `field::Type` → constant field (accessed via `_.field`)
+The macro separates fields into three roles:
 
-The order of fields is preserved in the generated struct.
+- `field::P`: parameter descriptor field. The generated struct stores it as
+  `description_of_field`, constrained to `AbstractParameter`. Inside `body`,
+  `field` is already the resolved numeric value, computed with
+  `BuildConstructors.value(c.description_of_field; pars)`.
+- `field::SomeType`: constant field. The generated struct stores it directly with
+  the declared type. Inside `body`, access it as `_.field`.
+- `field`: parametric field. The generated struct stores it directly with an
+  inferred type parameter. This is useful for nested constructors or arbitrary
+  user objects. Inside `body`, access it as `_.field`.
 
-# Example
+The generated constructor argument order is parametric fields first, parameter
+descriptor fields second, and constant fields last. This keeps all generated
+constructors predictable even when fields are declared in a mixed order.
+
+Inside `body`, parameter names such as `μ` and `σ` refer to resolved values.
+Non-parameter fields must be accessed through the placeholder `_`, for example
+`_.support` or `_.child`. This makes it visually clear which values are part of
+the constructor metadata and which values are runtime parameters.
+
+# Examples
 ```julia
 @with_parameters Gaussian; μ::P, σ::P, support::Tuple{Float64,Float64} begin
     truncated(Normal(μ, σ), _.support[1], _.support[2])
 end
 
 @with_parameters ScaleModel; D, scale::P begin
-    build_model(_.D, pars) * scale
+    child = build_model(_.D, pars)
+    x -> scale * child(x)
 end
 ```
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -166,8 +166,8 @@ end
 
     @test model1 isa Distribution
     @test model2 isa Distribution
-    @test pdf(model1, 1.1) == 0.01570665415299559
-    @test pdf(model2, 1.1) == 0.01570665415299559
+    @test pdf(model1, 1.1) ≈ 0.01570665415299559
+    @test pdf(model2, 1.1) ≈ 0.01570665415299559
 end
 
 @testset "Extend BuildConstructors" begin

--- a/test/test-parameter.jl
+++ b/test/test-parameter.jl
@@ -120,6 +120,9 @@ end
     @test upper_bounds.c1 == Inf
     @test upper_bounds.fs == 1.0
     @test keys(upper_bounds) == (:m, :Γ, :σ, :c1, :fs)
+
+    p_default = AdvancedParameter("advanced", 1.0)
+    @test running_upper_boundaries(p_default) == (advanced = Inf,)
 end
 
 @testset "running_lower_boundaries" begin
@@ -146,4 +149,7 @@ end
     @test lower_bounds.c1 == -Inf
     @test lower_bounds.fs == 0.0
     @test keys(lower_bounds) == (:m, :Γ, :σ, :c1, :fs)
+
+    p_default = AdvancedParameter("advanced", 1.0)
+    @test running_lower_boundaries(p_default) == (advanced = -Inf,)
 end


### PR DESCRIPTION
## Summary

- Rework the README around the general constructor-wrapper pattern instead of leading with the PRB-specific use case.
- Add an essential vs optional section to separate the minimal API from convenience layers like serialization and PRB helpers.
- Expand @with_parameters documentation in both the README and macro docstring, including generated names, field roles, _ access, and field ordering.
- Add docstrings for the main public extension points and built-in parameter descriptor methods.
- Stabilize a serialization round-trip test by using approximate comparison for floating-point PDFs.

## Validation

- julia --project=. -e 'using Pkg; Pkg.instantiate()'
- julia --project=. -e 'using Pkg; Pkg.test()'