### PR TITLE
[codex] Add docs tutorial for Optim and Minuit2

### DIFF
--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -1,0 +1,43 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - "src/**"
+      - "Project.toml"
+      - ".github/workflows/Docs.yml"
+  pull_request:
+    paths:
+      - "docs/**"
+      - "src/**"
+      - "Project.toml"
+      - ".github/workflows/Docs.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  docbuild:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: "1"
+          arch: x64
+      - uses: julia-actions/cache@v3
+        with:
+          cache-name: docs
+      - name: Install and build docs
+        shell: julia --project=docs --color=yes {0}
+        run: |
+          using Pkg
+          Pkg.develop(PackageSpec(path=pwd()))
+          Pkg.instantiate()
+      - name: Build HTML
+        run: julia --project=docs docs/make.jl

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Manifest.toml
+docs/build/

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,10 @@
+[deps]
+BuildConstructors = "63b9b590-f22f-4e79-810f-ea9ba6849c26"
+ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Minuit2 = "37821647-3276-4ed8-9a4e-bc9886b3c106"
+Optim = "429524aa-4258-5aef-a3af-852621145aeb"
+
+[compat]
+Documenter = "1"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -5,6 +5,7 @@ Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Minuit2 = "37821647-3276-4ed8-9a4e-bc9886b3c106"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,28 @@
+using BuildConstructors
+using Documenter
+
+DocMeta.setdocmeta!(
+    BuildConstructors,
+    :DocTestSetup,
+    :(using BuildConstructors);
+    recursive = true,
+)
+
+makedocs(;
+    modules = [BuildConstructors],
+    sitename = "BuildConstructors.jl",
+    format = Documenter.HTML(;
+        prettyurls = get(ENV, "CI", "false") == "true",
+        canonical = "https://mikhailmikhasenko.github.io/BuildConstructors.jl",
+    ),
+    pages = [
+        "Home" => "index.md",
+        "Tutorials" => [
+            "Nested Constructors" => "tutorials/nested-constructors.md",
+            "Optim with ComponentArrays" => "tutorials/optim-componentarrays.md",
+            "Minuit2 with ComponentArrays" => "tutorials/minuit2-componentarrays.md",
+        ],
+    ],
+    doctest = false,
+    checkdocs = :exports,
+)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -23,6 +23,6 @@ makedocs(;
             "Minuit2 with ComponentArrays" => "tutorials/minuit2-componentarrays.md",
         ],
     ],
-    doctest = false,
+    doctest = true,
     checkdocs = :exports,
 )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,55 @@
+# BuildConstructors.jl
+
+`BuildConstructors.jl` separates model construction from parameter metadata.
+Instead of storing fit-specific state inside the model object itself, a constructor
+stores descriptors such as `Fixed`, `Running`, `FlexibleParameter`, and
+`AdvancedParameter`. The model is then created with `build_model(constructor, pars)`.
+
+This is useful when the final object should stay domain-native, immutable, or owned
+by another package, while fitting code still needs names, starting values, bounds,
+uncertainties, and fixed/free state.
+
+## Core Workflow
+
+```julia
+using BuildConstructors
+using Distributions
+
+@with_parameters(Gauss; μ::P, σ::P, begin
+    Normal(μ, σ)
+end)
+
+constructor = ConstructorOfGauss(
+    AdvancedParameter("μ", 0.0; boundaries = (-5.0, 5.0), uncertainty = 0.1),
+    AdvancedParameter("σ", 1.0; boundaries = (0.05, 5.0), uncertainty = 0.1),
+)
+
+start = running_values(constructor)
+model = build_model(constructor, start)
+```
+
+The constructor carries the metadata. The built object is just a `Normal`.
+
+## Public API
+
+```@docs
+BuildConstructors.AbstractParameter
+BuildConstructors.Fixed
+BuildConstructors.Running
+BuildConstructors.FlexibleParameter
+BuildConstructors.AdvancedParameter
+BuildConstructors.AbstractConstructor
+BuildConstructors.build_model
+BuildConstructors.running_values
+BuildConstructors.running_uncertainties
+BuildConstructors.running_lower_boundaries
+BuildConstructors.running_upper_boundaries
+BuildConstructors.fix!
+BuildConstructors.release!
+BuildConstructors.update!
+BuildConstructors.@with_parameters
+BuildConstructors.serialize
+BuildConstructors.deserialize
+BuildConstructors.convert_database_to_prb
+BuildConstructors.load_prb_model_from_json
+```

--- a/docs/src/tutorials/minuit2-componentarrays.md
+++ b/docs/src/tutorials/minuit2-componentarrays.md
@@ -1,0 +1,107 @@
+# Minuit2 with ComponentArrays
+
+`Minuit2.jl` can also work with `ComponentArray` inputs. Its public API documents
+the `componentarray_axes` mechanism used to reconstruct a `ComponentArray` from
+the vector passed through the Minuit callback. When the starting point is a
+`ComponentArray`, Minuit2 can infer those axes and call the objective with named
+parameters.
+
+The setup is the same as for `Optim.jl`: collect constructor metadata into
+`ComponentArray`s and write the objective in terms of named parameters.
+
+```julia
+using BuildConstructors
+using ComponentArrays
+using Distributions
+using Minuit2
+using Random
+
+@with_parameters(Gauss; μ::P, σ::P, begin
+    Normal(μ, σ)
+end)
+
+@with_parameters(Mixture; left, right, f_left::P, begin
+    MixtureModel(
+        [build_model(_.left, pars), build_model(_.right, pars)],
+        [f_left, 1 - f_left],
+    )
+end)
+
+constructor = ConstructorOfMixture(
+    ConstructorOfGauss(
+        AdvancedParameter("μ_left", -0.5; boundaries = (-5.0, 5.0), uncertainty = 0.1),
+        AdvancedParameter("σ_left", 1.0; boundaries = (0.05, 5.0), uncertainty = 0.05),
+    ),
+    ConstructorOfGauss(
+        AdvancedParameter("μ_right", 0.7; boundaries = (-5.0, 5.0), uncertainty = 0.1),
+        AdvancedParameter("σ_right", 1.0; boundaries = (0.05, 5.0), uncertainty = 0.05),
+    ),
+    AdvancedParameter("f_left", 0.5; boundaries = (0.0, 1.0), uncertainty = 0.02),
+)
+
+Random.seed!(2026)
+truth = MixtureModel([Normal(-1.0, 0.45), Normal(1.2, 0.35)], [0.6, 0.4])
+data = rand(truth, 2_000)
+```
+
+Prepare the starting point and metadata:
+
+```julia
+start = ComponentArray(running_values(constructor))
+lower = ComponentArray(running_lower_boundaries(constructor))
+upper = ComponentArray(running_upper_boundaries(constructor))
+
+errors = ComponentArray(
+    map(v -> coalesce(v, 0.1), running_uncertainties(constructor)),
+)
+limits = collect(zip(lower, upper))
+```
+
+The `coalesce` call gives Minuit a finite step size even if a descriptor has no
+stored uncertainty and reports `missing`.
+
+```julia
+function nll(c, data, pars)
+    model = build_model(c, pars)
+    return -sum(logpdf.(Ref(model), data))
+end
+
+objective(pars) = nll(constructor, data, pars)
+```
+
+Create and run Minuit:
+
+```julia
+minuit = Minuit(
+    objective,
+    start;
+    names = string.(keys(start)),
+    limits = limits,
+    error = collect(errors),
+    arraycall = true,
+    errordef = 0.5,
+)
+
+migrad!(minuit)
+hesse!(minuit)
+```
+
+Use `errordef = 0.5` for a negative log-likelihood. For a chi-square objective,
+use `errordef = 1.0`.
+
+With a `ComponentArray` starting point, `minuit.values` keeps the same named axes:
+
+```julia
+fitted = minuit.values
+
+fitted.μ_left
+fitted.σ_left
+fitted.f_left
+
+update!(constructor, fitted)
+running_values(constructor)
+```
+
+The important part is that the objective function itself can remain written in
+terms of named parameters. Minuit handles the numerical vector internally, while
+`ComponentArray` restores the names at the callback boundary.

--- a/docs/src/tutorials/nested-constructors.md
+++ b/docs/src/tutorials/nested-constructors.md
@@ -1,0 +1,78 @@
+# Nested Constructors
+
+Nested constructors are the main reason to keep parameter metadata outside the
+model object. A parent constructor can store child constructors, and
+`running_values`, `fix!`, `release!`, `update!`, and `build_model` recurse through
+the full tree.
+
+This example builds a weighted mixture of two normal distributions. The final
+object is a regular `MixtureModel` from `Distributions.jl`; the constructor tree
+only describes how to assemble it.
+
+```julia
+using BuildConstructors
+using Distributions
+
+@with_parameters(Gauss; μ::P, σ::P, begin
+    Normal(μ, σ)
+end)
+
+@with_parameters(Mixture; left, right, f_left::P, begin
+    MixtureModel(
+        [build_model(_.left, pars), build_model(_.right, pars)],
+        [f_left, 1 - f_left],
+    )
+end)
+```
+
+The plain fields `left` and `right` are child constructors. The `f_left::P` field
+is a parameter descriptor, so its resolved value is available as `f_left` inside
+the body.
+
+```julia
+constructor = ConstructorOfMixture(
+    ConstructorOfGauss(
+        AdvancedParameter("μ_left", -1.0; boundaries = (-5.0, 5.0), uncertainty = 0.1),
+        AdvancedParameter("σ_left", 0.8; boundaries = (0.05, 5.0), uncertainty = 0.05),
+    ),
+    ConstructorOfGauss(
+        AdvancedParameter("μ_right", 1.2; boundaries = (-5.0, 5.0), uncertainty = 0.1),
+        AdvancedParameter("σ_right", 0.5; boundaries = (0.05, 5.0), uncertainty = 0.05),
+    ),
+    AdvancedParameter("f_left", 0.6; boundaries = (0.0, 1.0), uncertainty = 0.02),
+)
+```
+
+The metadata collectors see every parameter in the nested tree:
+
+```julia
+running_values(constructor)
+# (μ_left = -1.0, σ_left = 0.8, μ_right = 1.2, σ_right = 0.5, f_left = 0.6)
+
+running_lower_boundaries(constructor)
+# (μ_left = -5.0, σ_left = 0.05, μ_right = -5.0, σ_right = 0.05, f_left = 0.0)
+```
+
+Use the collected values directly to build the model:
+
+```julia
+pars = running_values(constructor)
+model = build_model(constructor, pars)
+pdf(model, 0.0)
+```
+
+Mutating helpers also recurse through the tree:
+
+```julia
+fix!(constructor, (:σ_left, :σ_right))
+running_values(constructor)
+
+update!(constructor, (μ_left = -0.8, μ_right = 1.0, f_left = 0.55))
+running_values(constructor)
+
+release!(constructor, (:σ_left, :σ_right))
+```
+
+The pattern scales to deeper trees. A parent constructor does not need to know the
+concrete type of each child; it only needs to call `build_model(child, pars)` at
+the point where the final domain object is assembled.

--- a/docs/src/tutorials/optim-componentarrays.md
+++ b/docs/src/tutorials/optim-componentarrays.md
@@ -1,0 +1,97 @@
+# Optim with ComponentArrays
+
+`ComponentArrays.jl` is a convenient bridge between named constructor metadata and
+optimizers that expect array-like inputs. The objective can receive a
+`ComponentArray`, access parameters by name, and still satisfy `Optim.jl` because
+`ComponentArray` behaves like a vector.
+
+This tutorial fits the nested mixture constructor from the previous tutorial.
+
+```julia
+using BuildConstructors
+using ComponentArrays
+using Distributions
+using Optim
+using Random
+
+@with_parameters(Gauss; μ::P, σ::P, begin
+    Normal(μ, σ)
+end)
+
+@with_parameters(Mixture; left, right, f_left::P, begin
+    MixtureModel(
+        [build_model(_.left, pars), build_model(_.right, pars)],
+        [f_left, 1 - f_left],
+    )
+end)
+
+constructor = ConstructorOfMixture(
+    ConstructorOfGauss(
+        AdvancedParameter("μ_left", -0.5; boundaries = (-5.0, 5.0), uncertainty = 0.1),
+        AdvancedParameter("σ_left", 1.0; boundaries = (0.05, 5.0), uncertainty = 0.05),
+    ),
+    ConstructorOfGauss(
+        AdvancedParameter("μ_right", 0.7; boundaries = (-5.0, 5.0), uncertainty = 0.1),
+        AdvancedParameter("σ_right", 1.0; boundaries = (0.05, 5.0), uncertainty = 0.05),
+    ),
+    AdvancedParameter("f_left", 0.5; boundaries = (0.0, 1.0), uncertainty = 0.02),
+)
+```
+
+Generate a small toy sample:
+
+```julia
+Random.seed!(2026)
+truth = MixtureModel([Normal(-1.0, 0.45), Normal(1.2, 0.35)], [0.6, 0.4])
+data = rand(truth, 2_000)
+```
+
+Convert the constructor metadata to `ComponentArray`s:
+
+```julia
+start = ComponentArray(running_values(constructor))
+lower = ComponentArray(running_lower_boundaries(constructor))
+upper = ComponentArray(running_upper_boundaries(constructor))
+```
+
+The negative log-likelihood can pass the `ComponentArray` directly into
+`build_model`. Built-in parameter descriptors use `getproperty`, so `pars.μ_left`
+and `getproperty(pars, :μ_left)` work naturally.
+
+```julia
+function nll(c, data, pars)
+    model = build_model(c, pars)
+    return -sum(logpdf.(Ref(model), data))
+end
+
+objective(pars) = nll(constructor, data, pars)
+```
+
+Run a bounded optimization:
+
+```julia
+result = optimize(
+    objective,
+    lower,
+    upper,
+    start,
+    Fminbox(LBFGS()),
+)
+
+fitted = Optim.minimizer(result)
+```
+
+`fitted` is still a `ComponentArray`, so the result stays readable:
+
+```julia
+fitted.μ_left
+fitted.σ_left
+fitted.f_left
+
+update!(constructor, fitted)
+running_values(constructor)
+```
+
+This avoids the usual back-and-forth conversion between a flat vector and a
+`NamedTuple`. The optimizer sees an array; the model-building code sees named
+parameters.

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1,45 +1,3 @@
-"""
-    @with_parameters ModelName; fields... begin
-        body
-    end
-
-Generate a `ConstructorOfModelName` subtype of `AbstractConstructor` and a
-matching `build_model(::ConstructorOfModelName, pars)` method.
-
-The macro separates fields into three roles:
-
-- `field::P`: parameter descriptor field. The generated struct stores it as
-  `description_of_field`, constrained to `AbstractParameter`. Inside `body`,
-  `field` is already the resolved numeric value, computed with
-  `BuildConstructors.value(c.description_of_field; pars)`.
-- `field::SomeType`: constant field. The generated struct stores it directly with
-  the declared type. Inside `body`, access it as `_.field`.
-- `field`: parametric field. The generated struct stores it directly with an
-  inferred type parameter. This is useful for nested constructors or arbitrary
-  user objects. Inside `body`, access it as `_.field`.
-
-The generated constructor argument order is parametric fields first, parameter
-descriptor fields second, and constant fields last. This keeps all generated
-constructors predictable even when fields are declared in a mixed order.
-
-Inside `body`, parameter names such as `μ` and `σ` refer to resolved values.
-Non-parameter fields must be accessed through the placeholder `_`, for example
-`_.support` or `_.child`. This makes it visually clear which values are part of
-the constructor metadata and which values are runtime parameters.
-
-# Examples
-```julia
-@with_parameters Gaussian; μ::P, σ::P, support::Tuple{Float64,Float64} begin
-    truncated(Normal(μ, σ), _.support[1], _.support[2])
-end
-
-@with_parameters ScaleModel; D, scale::P begin
-    child = build_model(_.D, pars)
-    x -> scale * child(x)
-end
-```
-"""
-
 # Helper: Check if expression is a body block
 function is_body_block(expr)
     !(expr isa Expr) && return false
@@ -395,6 +353,47 @@ function parse_macro_arguments(model_name_expr, params_expr...)
     return model_name, ordered_fields, body
 end
 
+"""
+    @with_parameters ModelName; fields... begin
+        body
+    end
+
+Generate a `ConstructorOfModelName` subtype of `AbstractConstructor` and a
+matching `build_model(::ConstructorOfModelName, pars)` method.
+
+The macro separates fields into three roles:
+
+- `field::P`: parameter descriptor field. The generated struct stores it as
+  `description_of_field`, constrained to `AbstractParameter`. Inside `body`,
+  `field` is already the resolved numeric value, computed with
+  `BuildConstructors.value(c.description_of_field; pars)`.
+- `field::SomeType`: constant field. The generated struct stores it directly with
+  the declared type. Inside `body`, access it as `_.field`.
+- `field`: parametric field. The generated struct stores it directly with an
+  inferred type parameter. This is useful for nested constructors or arbitrary
+  user objects. Inside `body`, access it as `_.field`.
+
+The generated constructor argument order is parametric fields first, parameter
+descriptor fields second, and constant fields last. This keeps all generated
+constructors predictable even when fields are declared in a mixed order.
+
+Inside `body`, parameter names such as `μ` and `σ` refer to resolved values.
+Non-parameter fields must be accessed through the placeholder `_`, for example
+`_.support` or `_.child`. This makes it visually clear which values are part of
+the constructor metadata and which values are runtime parameters.
+
+# Examples
+```julia
+@with_parameters Gaussian; μ::P, σ::P, support::Tuple{Float64,Float64} begin
+    truncated(Normal(μ, σ), _.support[1], _.support[2])
+end
+
+@with_parameters ScaleModel; D, scale::P begin
+    child = build_model(_.D, pars)
+    x -> scale * child(x)
+end
+```
+"""
 macro with_parameters(model_name_expr, params_expr...)
     # Parse arguments sequentially: model name, fields, and body
     model_name, ordered_fields, body =


### PR DESCRIPTION
## Summary

- Add a Documenter.jl documentation scaffold under docs/.
- Add an API landing page with the core constructor workflow and public docs.
- Add a fitting tutorial showing how to connect constructor metadata to Optim.jl and Minuit2.jl.
- Attach the @with_parameters docstring to the macro definition so Documenter can include it.
- Ignore generated docs/build/ output.

## Validation

- julia --project=docs docs/make.jl
- julia --project=. test/runtests.jl