### PR TITLE
CI: use aarch64 Julia on macOS runners

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -21,13 +21,11 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                version:
-                    - "1.7"
-                    - "1"
-                os:
-                    - ubuntu-latest
-                    - macOS-latest
-                    - windows-latest
-                arch:
-                    - x64
                 allow_failure: [false]
+                include:
+                    - { version: "1.7", os: ubuntu-latest, arch: x64 }
+                    - { version: "1.7", os: macOS-latest, arch: aarch64 }
+                    - { version: "1.7", os: windows-latest, arch: x64 }
+                    - { version: "1", os: ubuntu-latest, arch: x64 }
+                    - { version: "1", os: macOS-latest, arch: aarch64 }
+                    - { version: "1", os: windows-latest, arch: x64 }


### PR DESCRIPTION
## Summary

GitHub `macOS-latest` runners are Apple Silicon. `julia-actions/setup-julia` rejects `arch: x64` on those hosts unless `force-arch: true` is set.

## Changes

- Replace the flat version × os × arch matrix with an explicit `include` list.
- Use `aarch64` for `macOS-latest` and `x64` for Ubuntu and Windows.

This matches the [setup-julia error message](https://github.com/julia-actions/setup-julia) recommending `aarch64` on arm64 macOS runners.

Made with [Cursor](https://cursor.com)