### PR TITLE
@with_parameters: bare field names in body (v0.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,4 @@ All notable changes to this project are documented in this file.
 ### Breaking
 
 - Deserialization no longer parses arbitrary Julia expressions from serialized `"type"` strings (previously `eval(Meta.parse(...))`). Only registered type names and simple identifiers resolvable in the extension module (if loaded), `BuildConstructors`, or `Base` are accepted. Parametric forms such as `Fixed{Float64}` in JSON are **not** supported unless you register an explicit name with `register!`. This closes a code-injection risk when loading untrusted JSON.
-- `@with_parameters`: do not use `_.field` in the body; use bare names that match the field list. Calls of the form `build_model(sym, pars)` must use a declared field name as `sym` when `sym` is a plain symbol (macro expansion checks this).
+- `@with_parameters`: do not use `_.field` in the body; use bare names that match the field list for constructor fields. Other `build_model` call patterns follow normal Julia scoping (undeclared names surface as runtime `UndefVarError` where appropriate).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ All notable changes to this project are documented in this file.
 ### Changed
 
 - Heavy physics-oriented dependencies (`Distributions`, `DistributionsHEP`, `JSON`, `NumericalDistributions`) are optional and loaded via the `PhysicsModelsExt` package extension when those packages are present.
+- `@with_parameters`: every field listed in the macro header is bound as a local inside the generated `build_model` (`field::P` via `value`, parametric and typed slots via `c.field`). Documentation, README, extension examples, and tutorials use bare names consistently.
+- `@with_parameters`: macro implementation trimmed (removed unused bookkeeping, combined prelude emission into one pass over fields).
+- Tests: `test/test-macro.jl` is loaded from `test/runtests.jl` so macro coverage runs under `Pkg.test()`.
 
 ### Breaking
 
 - Deserialization no longer parses arbitrary Julia expressions from serialized `"type"` strings (previously `eval(Meta.parse(...))`). Only registered type names and simple identifiers resolvable in the extension module (if loaded), `BuildConstructors`, or `Base` are accepted. Parametric forms such as `Fixed{Float64}` in JSON are **not** supported unless you register an explicit name with `register!`. This closes a code-injection risk when loading untrusted JSON.
+- `@with_parameters`: do not use `_.field` in the body; use bare names that match the field list. Calls of the form `build_model(sym, pars)` must use a declared field name as `sym` when `sym` is a plain symbol (macro expansion checks this).

--- a/README.md
+++ b/README.md
@@ -198,7 +198,12 @@ field = BuildConstructors.value(c.description_of_field; pars)
 ```
 
 For `field::SomeType` and plain `field`, the macro binds `field = c.field` before the body.
-Every name in the field list is therefore available as a local variable alongside `pars`.
+Every name in the field list is therefore available as a local variable in the body.
+
+The name `pars` is separate from that list: it always refers to the second argument of
+the generated `build_model(c, pars)`, i.e. the caller-supplied parameter bundle. Forward
+it unchanged when composing nested constructors (`build_model(child, pars)`) so inner
+`build_model` methods see the same parameters.
 
 For example:
 

--- a/README.md
+++ b/README.md
@@ -186,8 +186,8 @@ Field declarations have three forms, and the distinction is important:
 | Form | Meaning |
 | --- | --- |
 | `field::P` | A parameter descriptor field, available in the body as the resolved value `field`. |
-| `field::SomeType` | A constant field, accessed in the body as `_.field`. |
-| `field` | A parametric field, useful for nested constructors, accessed as `_.field`. |
+| `field::SomeType` | A constant field; in the body use bare `field` (bound from the constructor instance). |
+| `field` | A parametric field (nested constructors, etc.); in the body use bare `field`. |
 
 For `field::P`, the generated struct field is named `description_of_field`.
 This keeps the constructor honest: it stores the parameter description, not the
@@ -197,16 +197,14 @@ current numeric value. During `build_model`, the macro inserts:
 field = BuildConstructors.value(c.description_of_field; pars)
 ```
 
-For `field::SomeType` and plain `field`, the value is stored directly in the
-constructor. In the body, those fields must be accessed through `_`, as in
-`_.support` or `_.child`. Direct access is rejected by the macro so that parameter
-values and constructor fields do not get mixed up silently.
+For `field::SomeType` and plain `field`, the macro binds `field = c.field` before the body.
+Every name in the field list is therefore available as a local variable alongside `pars`.
 
 For example:
 
 ```julia
 @with_parameters(Scaled; child, scale::P, begin
-    child_model = build_model(_.child, pars)
+    child_model = build_model(child, pars)
     x -> scale * child_model(x)
 end)
 ```
@@ -224,7 +222,7 @@ declaration such as:
 
 ```julia
 @with_parameters(Windowed; model, μ::P, support::Tuple{Float64,Float64}, begin
-    truncated(build_model(_.model, pars), _.support[1] + μ, _.support[2] + μ)
+    truncated(build_model(model, pars), support[1] + μ, support[2] + μ)
 end)
 ```
 

--- a/docs/example1.jl
+++ b/docs/example1.jl
@@ -11,17 +11,17 @@ theme(:boxed)
 @with_parameters(Gauss; μ::P, σ::P, begin Normal(μ, σ) end)
 @with_parameters(NormalizeAbs2Abs2; D, support::Tuple{Float64,Float64},
     begin
-        NumericallyIntegrable(e->abs2(build_model(_.D, pars)(e^2)), _.support)
+        NumericallyIntegrable(e->abs2(build_model(D, pars)(e^2)), support)
     end)
 @with_parameters(BW; m::P, Γ::P, begin BreitWigner(m, Γ) end)
-@with_parameters(Cut; cModel, support::Tuple{Float64,Float64}, begin truncated(build_model(_.cModel, pars), _.support[1], _.support[2]) end)
-@with_parameters(S; cModel, scale::P, begin build_model(_.cModel, pars) * scale end)
+@with_parameters(Cut; cModel, support::Tuple{Float64,Float64}, begin truncated(build_model(cModel, pars), support[1], support[2]) end)
+@with_parameters(S; cModel, scale::P, begin build_model(cModel, pars) * scale end)
 @with_parameters(Comb; 
     cModel1,
     cModel2, 
     weight::P,
     begin
-        MixtureModel([build_model(_.cModel1, pars), build_model(_.cModel2, pars)], [weight, 1-weight])
+        MixtureModel([build_model(cModel1, pars), build_model(cModel2, pars)], [weight, 1-weight])
     end
 )
 

--- a/docs/src/tutorials/minuit2-componentarrays.md
+++ b/docs/src/tutorials/minuit2-componentarrays.md
@@ -22,7 +22,7 @@ end)
 
 @with_parameters(Mixture; left, right, f_left::P, begin
     MixtureModel(
-        [build_model(_.left, pars), build_model(_.right, pars)],
+        [build_model(left, pars), build_model(right, pars)],
         [f_left, 1 - f_left],
     )
 end)

--- a/docs/src/tutorials/nested-constructors.md
+++ b/docs/src/tutorials/nested-constructors.md
@@ -19,7 +19,7 @@ end)
 
 @with_parameters(Mixture; left, right, f_left::P, begin
     MixtureModel(
-        [build_model(_.left, pars), build_model(_.right, pars)],
+        [build_model(left, pars), build_model(right, pars)],
         [f_left, 1 - f_left],
     )
 end)

--- a/docs/src/tutorials/optim-componentarrays.md
+++ b/docs/src/tutorials/optim-componentarrays.md
@@ -20,7 +20,7 @@ end)
 
 @with_parameters(Mixture; left, right, f_left::P, begin
     MixtureModel(
-        [build_model(_.left, pars), build_model(_.right, pars)],
+        [build_model(left, pars), build_model(right, pars)],
         [f_left, 1 - f_left],
     )
 end)

--- a/ext/PhysicsModelsExt/phys-res-bgd-model.jl
+++ b/ext/PhysicsModelsExt/phys-res-bgd-model.jl
@@ -7,10 +7,10 @@
     support::Tuple{Float64,Float64},
     grid_size::Int,
     begin
-        p = build_model(_.model_p, pars)
-        r = build_model(_.model_r, pars)
-        b = build_model(_.model_b, pars)
-        r_conv_p = truncated(fft_convolve(r, p; gridsize = _.grid_size), _.support[1], _.support[2])
+        p = build_model(model_p, pars)
+        r = build_model(model_r, pars)
+        b = build_model(model_b, pars)
+        r_conv_p = truncated(fft_convolve(r, p; gridsize = grid_size), support[1], support[2])
         MixtureModel([r_conv_p, b], [fs, 1-fs])
     end
 )

--- a/ext/PhysicsModelsExt/primitives.jl
+++ b/ext/PhysicsModelsExt/primitives.jl
@@ -5,7 +5,7 @@
     Γ::P,
     support::Tuple{Float64,Float64},
     begin
-        NumericallyIntegrable(e->1/abs2(m^2-e^2 - 1im*m*Γ), _.support)
+        NumericallyIntegrable(e->1/abs2(m^2-e^2 - 1im*m*Γ), support)
     end
 )
 
@@ -18,7 +18,7 @@
         μ = 0.9666176144464419 # reduced mass of D0 and D*0 in GeV/c^2
         k1(E::Complex) = 1im * sqrt(-2μ * (E * 1e-3))
         k1(E::Real) = k1(E + 1e-7im)
-        NumericallyIntegrable(e->1/abs2(-γre-1im*γim-1im*k1(e)), _.support)
+        NumericallyIntegrable(e->1/abs2(-γre-1im*γim-1im*k1(e)), support)
     end
 )
 
@@ -32,7 +32,7 @@
     σ::P,
     support::Tuple{Float64,Float64},
     begin
-        truncated(Normal(μ, σ), _.support[1], _.support[2])
+        truncated(Normal(μ, σ), support[1], support[2])
     end
 )
 
@@ -53,10 +53,10 @@
         σ1_MeV, σ2_MeV = (σ1, σ2) .* 1e3
         α = c0 * (c1 * σ1)^c2 / (1 + (c1 * σ1)^c2)
         d1 = CrystalBall(0.0, σ1_MeV, α, n)
-        td1 = truncated(d1, _.support[1], _.support[2])
+        td1 = truncated(d1, support[1], support[2])
 
         hyp_sec(x, μ, σ) = 1/(2*σ)*sech(π/2 * (x-μ)/σ)
-        td2 = NumericallyIntegrable(x->hyp_sec(x, 0.0, σ2_MeV), _.support)
+        td2 = NumericallyIntegrable(x->hyp_sec(x, 0.0, σ2_MeV), support)
         # mixture model
         w * MixtureModel([td1, td2], [fr1, 1-fr1])
     end
@@ -72,7 +72,7 @@
     c1C::P,
     support::Tuple{Float64,Float64},
     begin
-        Chebyshev([1, c1C], _.support[1], _.support[2])
+        Chebyshev([1, c1C], support[1], support[2])
     end
 )
 
@@ -84,6 +84,6 @@
     c2C::P,
     support::Tuple{Float64,Float64},
     begin
-        Chebyshev([1, c1C, c2C], _.support[1], _.support[2])
+        Chebyshev([1, c1C, c2C], support[1], support[2])
     end
 )

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -18,7 +18,7 @@ end
 
 # Parsed field roles for `@with_parameters` (same payload shape, different lowering — kept
 # as distinct types so dispatch selects struct generation and build_model extraction).
-"""Bare `field` in the macro list → struct slot `field::Pi` (unconstrained type param); use `_.field` in the body."""
+"""Bare `field` in the macro list → struct slot `field::Pi` (unconstrained type param); in the body use bare `field`."""
 struct ParametricField
     name::Symbol
 end
@@ -60,51 +60,31 @@ function parse_field(expr)
     end
 end
 
-# Helper: Find all field usages (_.field_name) in expression tree and transform to c.field_name
-# Also validates that fields are accessed via _.field pattern, not directly
-function find_field_usages(expr, all_declared_fields, param_names)
-    used_fields = Set{Symbol}()
-    invalid_usages = Symbol[]  # Fields used directly without _.field pattern
-
-    function traverse_and_transform(e)
+# `build_model(child, pars)` must use a declared field name as `child` when it is a plain symbol.
+function validate_build_model_nested_refs(expr, declared_fields::Set{Symbol})
+    function walk(e)
         if e isa Expr
-            # Check for _.field_name pattern and transform to c.field_name
-            if e.head == :. && length(e.args) == 2
-                if e.args[1] == :_ && e.args[2] isa QuoteNode
-                    field_name = e.args[2].value
-                    if field_name isa Symbol
-                        push!(used_fields, field_name)
-                        # Transform _.field to c.field
-                        e.args[1] = :c
-                    end
+            if e.head === :call &&
+               length(e.args) == 3 &&
+               e.args[1] === :build_model &&
+               e.args[3] === :pars
+                nest = e.args[2]
+                if nest isa Symbol && !(nest in declared_fields)
+                    error(
+                        "@with_parameters: `build_model($(nest), pars)` uses `$(nest)`, which is not declared in the field list. " *
+                        "Declare it as $(nest), $(nest)::P, or $(nest)::Type.",
+                    )
                 end
             end
-            # Recursively traverse all sub-expressions
             for arg in e.args
-                traverse_and_transform(arg)
+                walk(arg)
             end
-        elseif e isa Symbol
-            # Check if this symbol is a declared field being used directly (invalid)
-            # But ignore if it's a parameter name (those are valid)
-            if e in all_declared_fields && !(e in param_names)
-                push!(invalid_usages, e)
-            end
+        elseif e isa QuoteNode && e.value isa Expr
+            walk(e.value)
         end
     end
-
-    traverse_and_transform(expr)
-
-    # Report invalid usages
-    if !isempty(invalid_usages)
-        unique_invalid = unique(invalid_usages)
-        field_list = join(["'$(f)'" for f in unique_invalid], ", ")
-        error(
-            "Field(s) $field_list are used directly but must be accessed via '_.field_name' pattern. " *
-            "For example, use '_.$(unique_invalid[1])' instead of '$(unique_invalid[1])'",
-        )
-    end
-
-    return used_fields
+    walk(expr)
+    return nothing
 end
 
 # Helper: Generate type parameters for struct
@@ -149,37 +129,32 @@ end
 
 function add_struct_field!(struct_fields, field::ConstantField, _)
     push!(struct_fields.args, Expr(:(::), field.name, field.type_expr))
-    return nothing  # No index to update
+    return nothing  # unused index slot for ConstantField
 end
 
-# Multiple dispatch: Check field type for filtering
-field_type(::ParametricField) = :parametric
-field_type(::DescriptorField) = :parameter
-field_type(::ConstantField) = :constant
-
 # Helper: Generate struct fields in reordered format: parametric first, then parameters, then constants
-function generate_struct_fields(ordered_fields, param_type_params, parametric_type_params)
+function generate_struct_fields(ordered_fields)
     struct_fields = Expr(:block)
 
     # Track indices for type parameters
     param_idx = 1
     parametric_idx = 1
 
-    # First pass: add parametric fields
+    # Parametric fields (declaration order)
     for field in ordered_fields
-        field_type(field) == :parametric &&
+        field isa ParametricField &&
             (parametric_idx = add_struct_field!(struct_fields, field, parametric_idx))
     end
 
-    # Second pass: add parameter fields
+    # Descriptor fields (`::P`)
     for field in ordered_fields
-        field_type(field) == :parameter &&
+        field isa DescriptorField &&
             (param_idx = add_struct_field!(struct_fields, field, param_idx))
     end
 
-    # Third pass: add constant fields
+    # Typed constant fields
     for field in ordered_fields
-        field_type(field) == :constant && add_struct_field!(struct_fields, field, nothing)
+        field isa ConstantField && add_struct_field!(struct_fields, field, nothing)
     end
 
     return struct_fields
@@ -205,16 +180,9 @@ function generate_struct_definition(
     )
 end
 
-# Multiple dispatch: Extract parameter from field (only for DescriptorField / `::P`)
-# Mutates param_extractions and param_names
-function extract_parameter!(
-    param_extractions,
-    param_names,
-    field::DescriptorField,
-    value_ref,
-)
+# Multiple dispatch: Extract parameter value for DescriptorField (`::P`)
+function extract_parameter!(param_extractions, field::DescriptorField, value_ref)
     field_name = Symbol("description_of_", field.name)
-    push!(param_names, field.name)
     push!(
         param_extractions.args,
         Expr(
@@ -231,42 +199,31 @@ function extract_parameter!(
     return nothing
 end
 
-extract_parameter!(::Any, ::Any, ::ParametricField, _) = nothing
-extract_parameter!(::Any, ::Any, ::ConstantField, _) = nothing
+extract_parameter!(::Any, ::ParametricField, ::Any) = nothing
+extract_parameter!(::Any, ::ConstantField, ::Any) = nothing
 
-# Multiple dispatch: Check if field is a parameter field
-is_parameter_field(::DescriptorField) = true
-is_parameter_field(::ParametricField) = false
-is_parameter_field(::ConstantField) = false
+function add_slot_bindings!(bindings_block, field::Union{ParametricField, ConstantField})
+    push!(bindings_block.args, Expr(:(=), field.name, Expr(:., :c, QuoteNode(field.name))))
+    return nothing
+end
+add_slot_bindings!(::Any, ::DescriptorField) = nothing
 
-# Multiple dispatch: Get parameter name (only for DescriptorField)
-get_parameter_name(field::DescriptorField) = field.name
-get_parameter_name(::ParametricField) = nothing
-get_parameter_name(::ConstantField) = nothing
-
-# Multiple dispatch: Count fields by type using dispatch
-count_field_type(::Type{DescriptorField}, fields) =
-    count(f -> field_type(f) == :parameter, fields)
-count_field_type(::Type{ParametricField}, fields) =
-    count(f -> field_type(f) == :parametric, fields)
+# Multiple dispatch: Count fields by type
+count_descriptor_fields(fields) = count(f -> f isa DescriptorField, fields)
+count_parametric_fields(fields) = count(f -> f isa ParametricField, fields)
 
 # Helper: Generate build_model function
 function generate_build_model_function(constructor_name, ordered_fields, body)
     value_ref = Expr(:., :BuildConstructors, QuoteNode(:value))
 
-    # Extract parameters: param = value(c.description_of_{param}; pars)
-    param_extractions = Expr(:block)
-    param_names = Symbol[]
-
+    # Descriptor locals: param = value(c.description_of_{param}; pars)
+    build_model_body = Expr(:block)
     for field in ordered_fields
-        extract_parameter!(param_extractions, param_names, field, value_ref)
+        add_slot_bindings!(build_model_body, field)
+        extract_parameter!(build_model_body, field, value_ref)
     end
 
-    # Combine parameter extractions with user body
-    build_model_body = Expr(:block)
-    append!(build_model_body.args, param_extractions.args)
-
-    # Add user body
+    # User body
     if body isa Expr && body.head == :block
         append!(build_model_body.args, body.args)
     else
@@ -371,28 +328,27 @@ The macro separates fields into three roles:
   `field` is already the resolved numeric value, computed with
   `BuildConstructors.value(c.description_of_field; pars)`.
 - `field::SomeType`: constant field. The generated struct stores it directly with
-  the declared type. Inside `body`, access it as `_.field`.
+  the declared type. Inside `body`, use bare `field`.
 - `field`: parametric field. The generated struct stores it directly with an
   inferred type parameter. This is useful for nested constructors or arbitrary
-  user objects. Inside `body`, access it as `_.field`.
+  user objects. Inside `body`, use bare `field`.
 
 The generated constructor argument order is parametric fields first, parameter
 descriptor fields second, and constant fields last. This keeps all generated
 constructors predictable even when fields are declared in a mixed order.
 
-Inside `body`, parameter names such as `μ` and `σ` refer to resolved values.
-Non-parameter fields must be accessed through the placeholder `_`, for example
-`_.support` or `_.child`. This makes it visually clear which values are part of
-the constructor metadata and which values are runtime parameters.
+Inside `body`, every field name from the header is a local binding: parameter
+descriptors (`::P`) are resolved via `BuildConstructors.value`; parametric and
+constant fields are read from `c`. Only those names appear as locals together with `pars`.
 
 # Examples
 ```julia
 @with_parameters Gaussian; μ::P, σ::P, support::Tuple{Float64,Float64} begin
-    truncated(Normal(μ, σ), _.support[1], _.support[2])
+    truncated(Normal(μ, σ), support[1], support[2])
 end
 
 @with_parameters ScaleModel; D, scale::P begin
-    child = build_model(_.D, pars)
+    child = build_model(D, pars)
     x -> scale * child(x)
 end
 ```
@@ -402,41 +358,18 @@ macro with_parameters(model_name_expr, params_expr...)
     model_name, ordered_fields, body =
         parse_macro_arguments(model_name_expr, params_expr...)
 
-    # Collect all declared field names and parameter names
-    all_declared_fields = Set{Symbol}()
-    param_names = Symbol[]
+    declared_fields = Set(f.name for f in ordered_fields)
+    validate_build_model_nested_refs(body, declared_fields)
 
-    for field in ordered_fields
-        push!(all_declared_fields, field.name)
-        param_name = get_parameter_name(field)
-        param_name !== nothing && push!(param_names, param_name)
-    end
-
-    # Validate field usages in body
-    param_names_set = Set(param_names)
-    used_fields = find_field_usages(body, all_declared_fields, param_names_set)
-
-    # Check that all used fields are declared
-    for field in used_fields
-        if !(field in all_declared_fields)
-            error(
-                "Field '$(field)' is used in the body but not declared. " *
-                "Please declare it: $(field), $(field)::P, or $(field)::Type",
-            )
-        end
-    end
-
-    # Count fields by type
-    n_params = count_field_type(DescriptorField, ordered_fields)
-    n_parametric = count_field_type(ParametricField, ordered_fields)
+    n_descriptor = count_descriptor_fields(ordered_fields)
+    n_parametric = count_parametric_fields(ordered_fields)
 
     # Generate code
     constructor_name = Symbol("ConstructorOf", model_name)
 
     param_type_params, parametric_type_params =
-        generate_type_parameters(n_params, n_parametric)
-    struct_fields =
-        generate_struct_fields(ordered_fields, param_type_params, parametric_type_params)
+        generate_type_parameters(n_descriptor, n_parametric)
+    struct_fields = generate_struct_fields(ordered_fields)
     struct_def = generate_struct_definition(
         constructor_name,
         param_type_params,

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -154,7 +154,7 @@ function generate_struct_definition(
 end
 
 # Multiple dispatch: Extract parameter value for DescriptorField (`::P`)
-function extract_parameter!(param_extractions, field::DescriptorField, value_ref)
+function extract_parameter!(param_extractions, field::DescriptorField, value_ref, c_inst)
     field_name = Symbol("description_of_", field.name)
     push!(
         param_extractions.args,
@@ -165,21 +165,24 @@ function extract_parameter!(param_extractions, field::DescriptorField, value_ref
                 :call,
                 value_ref,
                 Expr(:parameters, :pars),
-                Expr(:., :c, QuoteNode(field_name)),
+                Expr(:., c_inst, QuoteNode(field_name)),
             ),
         ),
     )
     return nothing
 end
 
-extract_parameter!(::Any, ::ParametricField, ::Any) = nothing
-extract_parameter!(::Any, ::ConstantField, ::Any) = nothing
+extract_parameter!(::Any, ::ParametricField, ::Any, ::Any) = nothing
+extract_parameter!(::Any, ::ConstantField, ::Any, ::Any) = nothing
 
-function add_slot_bindings!(bindings_block, field::Union{ParametricField, ConstantField})
-    push!(bindings_block.args, Expr(:(=), field.name, Expr(:., :c, QuoteNode(field.name))))
+function add_slot_bindings!(bindings_block, field::Union{ParametricField, ConstantField}, c_inst)
+    push!(
+        bindings_block.args,
+        Expr(:(=), field.name, Expr(:., c_inst, QuoteNode(field.name))),
+    )
     return nothing
 end
-add_slot_bindings!(::Any, ::DescriptorField) = nothing
+add_slot_bindings!(::Any, ::DescriptorField, ::Any) = nothing
 
 # Multiple dispatch: Count fields by type
 count_descriptor_fields(fields) = count(f -> f isa DescriptorField, fields)
@@ -188,12 +191,15 @@ count_parametric_fields(fields) = count(f -> f isa ParametricField, fields)
 # Helper: Generate build_model function
 function generate_build_model_function(constructor_name, ordered_fields, body)
     value_ref = Expr(:., :BuildConstructors, QuoteNode(:value))
+    # Gensym the constructor formal so slot bindings named `c` cannot shadow accesses
+    # to the instance (bindings run in declaration order).
+    c_inst = gensym(:c)
 
-    # Descriptor locals: param = value(c.description_of_{param}; pars)
+    # Descriptor locals: param = value(<ctor>.description_of_{param}; pars)
     build_model_body = Expr(:block)
     for field in ordered_fields
-        add_slot_bindings!(build_model_body, field)
-        extract_parameter!(build_model_body, field, value_ref)
+        add_slot_bindings!(build_model_body, field, c_inst)
+        extract_parameter!(build_model_body, field, value_ref, c_inst)
     end
 
     # User body
@@ -207,7 +213,7 @@ function generate_build_model_function(constructor_name, ordered_fields, body)
     build_model_ref = Expr(:., :BuildConstructors, QuoteNode(:build_model))
     return Expr(
         :function,
-        Expr(:call, build_model_ref, Expr(:(::), :c, constructor_name), :pars),
+        Expr(:call, build_model_ref, Expr(:(::), c_inst, constructor_name), :pars),
         build_model_body,
     )
 end
@@ -312,10 +318,11 @@ constructors predictable even when fields are declared in a mixed order.
 
 Inside `body`, every field name from the header is a local binding: parameter
 descriptors (`::P`) are resolved via `BuildConstructors.value`; parametric and
-constant fields are read from `c`.
+constant slots are copied from fields of the constructor instance.
 
 The name `pars` does not appear in the field list; it is fixed by the macro as the
-second argument of the generated `build_model(c, pars)`. That value is whatever the
+second argument of the generated `build_model` method (after the constructor
+argument). That value is whatever the
 caller supplied as the second argument when building this constructor (the same role
 as `pars` throughout `build_model` in this package). When you call `build_model` on a
 nested constructor inside `body`, pass that object through as the second argument —

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -312,8 +312,17 @@ constructors predictable even when fields are declared in a mixed order.
 
 Inside `body`, every field name from the header is a local binding: parameter
 descriptors (`::P`) are resolved via `BuildConstructors.value`; parametric and
-constant fields are read from `c`. Those names appear as locals together with `pars`
-and with any other bindings normal Julia rules allow (e.g. loop variables).
+constant fields are read from `c`.
+
+The name `pars` does not appear in the field list; it is fixed by the macro as the
+second argument of the generated `build_model(c, pars)`. That value is whatever the
+caller supplied as the second argument when building this constructor (the same role
+as `pars` throughout `build_model` in this package). When you call `build_model` on a
+nested constructor inside `body`, pass that object through as the second argument —
+typically `build_model(inner, pars)` — so inner constructors resolve parameters against
+the same container.
+
+Other locals follow normal Julia scoping (e.g. loop variables).
 
 # Examples
 ```julia

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -60,33 +60,6 @@ function parse_field(expr)
     end
 end
 
-# `build_model(child, pars)` must use a declared field name as `child` when it is a plain symbol.
-function validate_build_model_nested_refs(expr, declared_fields::Set{Symbol})
-    function walk(e)
-        if e isa Expr
-            if e.head === :call &&
-               length(e.args) == 3 &&
-               e.args[1] === :build_model &&
-               e.args[3] === :pars
-                nest = e.args[2]
-                if nest isa Symbol && !(nest in declared_fields)
-                    error(
-                        "@with_parameters: `build_model($(nest), pars)` uses `$(nest)`, which is not declared in the field list. " *
-                        "Declare it as $(nest), $(nest)::P, or $(nest)::Type.",
-                    )
-                end
-            end
-            for arg in e.args
-                walk(arg)
-            end
-        elseif e isa QuoteNode && e.value isa Expr
-            walk(e.value)
-        end
-    end
-    walk(expr)
-    return nothing
-end
-
 # Helper: Generate type parameters for struct
 # Returns (param_type_params, parametric_type_params) where:
 # - param_type_params: type parameters for AbstractParameter fields (T1, T2, ...)
@@ -339,7 +312,8 @@ constructors predictable even when fields are declared in a mixed order.
 
 Inside `body`, every field name from the header is a local binding: parameter
 descriptors (`::P`) are resolved via `BuildConstructors.value`; parametric and
-constant fields are read from `c`. Only those names appear as locals together with `pars`.
+constant fields are read from `c`. Those names appear as locals together with `pars`
+and with any other bindings normal Julia rules allow (e.g. loop variables).
 
 # Examples
 ```julia
@@ -357,9 +331,6 @@ macro with_parameters(model_name_expr, params_expr...)
     # Parse arguments sequentially: model name, fields, and body
     model_name, ordered_fields, body =
         parse_macro_arguments(model_name_expr, params_expr...)
-
-    declared_fields = Set(f.name for f in ordered_fields)
-    validate_build_model_nested_refs(body, declared_fields)
 
     n_descriptor = count_descriptor_fields(ordered_fields)
     n_parametric = count_parametric_fields(ordered_fields)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,6 +39,7 @@ using DistributionsHEP
 using JSON
 using NumericalDistributions
 include("physics_access.jl")
+include("test-macro.jl")
 
 @testset "BuildConstructors tests" begin
     # let # to be replaced by the line above once working

--- a/test/test-macro.jl
+++ b/test/test-macro.jl
@@ -158,4 +158,18 @@ end)
     @test built[1] isa Distribution
 end
 
+# Regression: constant slot named `c` declared before descriptors must not shadow the
+# generated constructor reference when extracting `::P` fields (binding order follows
+# the macro header).
+@with_parameters(FieldNamedCSlotConstFirst; c::Float64, λ::P, begin
+    c + λ
+end)
+
+@testset "constant slot named c before descriptors" begin
+    # Constructor order is descriptors first (`λ`), then typed constants (`c`), regardless of
+    # declaration order in the macro header (see package docs).
+    ct = ConstructorOfFieldNamedCSlotConstFirst(Fixed(10.0), 2.0)
+    @test build_model(ct, NamedTuple()) == 12.0
+end
+
 println("All macro tests passed!")

--- a/test/test-macro.jl
+++ b/test/test-macro.jl
@@ -144,30 +144,18 @@ end
     @test pdf(model, 0.0) > 0
 end
 
-# Test Case 6: Validation tests - should fail
-@testset "Macro validation errors" begin
-    # Helper to test that a macro call throws an error
-    function test_macro_error(expr, expected_msg)
-        err = try
-            eval(expr)
-            return nothing
-        catch e
-            @assert e isa LoadError && e.error isa ErrorException
-            return e.error
-        end
-        return err
-    end
+# Regression: no static check on `build_model(m, pars)` — `m` is a loop variable, not a field.
+@with_parameters(BatchMacro; models, begin
+    [build_model(m, pars) for m in models]
+end)
 
-    # Test: build_model(D, pars) with undeclared D should fail at macro expansion
-    err2 = test_macro_error(
-        :(@with_parameters(ScaleMacro3; scale::P, begin
-            build_model(D, pars) * scale
-        end)),
-        "not declared",
-    )
-    @test err2 !== nothing
-    @test err2 isa ErrorException
-    @test occursin("not declared", string(err2)) || occursin("Declare", string(err2))
+@testset "build_model in comprehension uses non-field locals" begin
+    inner = ConstructorOfGaussian(Fixed(0.0), Fixed(0.1), (-0.5, 0.5))
+    cs = ConstructorOfBatchMacro((inner, inner))
+    built = build_model(cs, NamedTuple())
+    @test built isa Vector
+    @test length(built) == 2
+    @test built[1] isa Distribution
 end
 
 println("All macro tests passed!")

--- a/test/test-macro.jl
+++ b/test/test-macro.jl
@@ -14,7 +14,7 @@ include("physics_access.jl")
     σ::P,
     support::Tuple{Float64,Float64},
     begin
-        truncated(Normal(μ, σ), _.support[1], _.support[2])
+        truncated(Normal(μ, σ), support[1], support[2])
     end
 )
 # Test instantiation - order: parametric fields, parameter fields, constant fields
@@ -51,7 +51,7 @@ end
     c1C::P,
     support::Tuple{Float64,Float64},
     begin
-        Chebyshev([1, c1C], _.support[1], _.support[2])
+        Chebyshev([1, c1C], support[1], support[2])
     end
 )
 
@@ -91,8 +91,8 @@ end
     n_bins::Int,
     begin
         # Use multiple constant fields
-        if μ > _.threshold
-            truncated(Normal(μ, σ), _.support[1], _.support[2])
+        if μ > threshold
+            truncated(Normal(μ, σ), support[1], support[2])
         else
             # Use n_bins for something
             Normal(μ, σ)
@@ -113,7 +113,12 @@ end
 
 # Test Case 5: Parametric fields (fields without type annotations)
 @with_parameters(ScaleMacro; D, scale::P, begin
-    build_model(_.D, pars) * scale
+    build_model(D, pars) * scale
+end)
+
+# Bare `D` works when `D` is a typed constant slot (`field::SomeType`).
+@with_parameters(ScaleMacroConstD; D::BuildConstructors.AbstractConstructor, scale::P, begin
+    build_model(D, pars) * scale
 end)
 
 @testset "Macro with parametric fields" begin
@@ -125,6 +130,15 @@ end)
     )
     @test cs.D isa ConstructorOfGaussian
     @test cs.description_of_scale isa Fixed
+    model = build_model(cs, NamedTuple())
+    @test model isa Distribution
+    @test pdf(model, 0.0) > 0
+end
+
+@testset "Macro constant slot: bare field name" begin
+    inner = ConstructorOfGaussian(Fixed(0.0), Fixed(0.1), (-0.5, 0.5))
+    # Argument order: descriptor fields, then constant fields.
+    cs = ConstructorOfScaleMacroConstD(Fixed(2.0), inner)
     model = build_model(cs, NamedTuple())
     @test model isa Distribution
     @test pdf(model, 0.0) > 0
@@ -144,33 +158,16 @@ end
         return err
     end
 
-    # Test: Field used directly (not via _.field) should fail
-    err1 = test_macro_error(
-        :(@with_parameters(
-            ScaleMacro2;
-            D::AbstractConstructor,
-            scale::P,
-            begin
-                build_model(D) * scale  # Should use _.D
-            end
-        )),
-        "_.field_name",
-    )
-    @test err1 !== nothing
-    @test err1 isa ErrorException
-    @test occursin("_.field_name", string(err1)) ||
-          occursin("must be accessed", string(err1))
-
-    # Test: Field used via _.field but not declared should fail
+    # Test: build_model(D, pars) with undeclared D should fail at macro expansion
     err2 = test_macro_error(
         :(@with_parameters(ScaleMacro3; scale::P, begin
-            build_model(_.D) * scale  # D not declared
+            build_model(D, pars) * scale
         end)),
         "not declared",
     )
     @test err2 !== nothing
     @test err2 isa ErrorException
-    @test occursin("not declared", string(err2)) || occursin("Please declare", string(err2))
+    @test occursin("not declared", string(err2)) || occursin("Declare", string(err2))
 end
 
 println("All macro tests passed!")


### PR DESCRIPTION
## Summary

This PR completes the `@with_parameters` ergonomics work for **v0.5.0**. In the generated `build_model`, **every name in the macro field list is a local**, together with `pars`:

- `field::P` → resolved via `BuildConstructors.value(c.description_of_field; pars)`
- Parametric (`field`) and typed constant (`field::SomeType`) slots → `field = getproperty(c, :field)`

Docs, README, tutorials, and `PhysicsModelsExt` examples use **bare names** consistently (no `_.field`).

## Breaking changes (release notes)

- **Do not use `_.field`** in macro bodies; use bare `field` matching the header.
- **Safe deserialization** (already part of v0.5.0): no `eval(Meta.parse(...))` on serialized `"type"` strings (see CHANGELOG).

## Review follow-up

Static validation of `build_model(sym, pars)` (requiring `sym` to be a declared field) was **removed** after review: it conflicted with normal Julia patterns (e.g. `[build_model(m, pars) for m in models]`) and did not handle keyword arguments. Typos / wrong names behave like ordinary Julia (**`UndefVarError`** where applicable).

## Other changes

- Macro implementation trimmed (dead helpers removed; prelude built in one pass over fields).
- `test/test-macro.jl` is loaded from `test/runtests.jl`; includes a regression test for `build_model` inside a comprehension.
- **CHANGELOG.md** consolidated under **0.5.0**.

## Testing

`Pkg.test()` passes locally.