### PR TITLE
Add parameter metadata and state collectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project are documented in this file.
 
+## 0.6.0
+
+### Added
+
+- Parameter metadata collectors: `parameter_values`, `parameter_uncertainties`, `parameter_lower_boundaries`, and `parameter_upper_boundaries`.
+- Parameter state name collectors: `parameter_names`, `running_names`, and `fixed_names`.
+- Filtered state metadata collectors: `running_values`, `running_uncertainties`, `running_lower_boundaries`, `running_upper_boundaries`, `fixed_values`, `fixed_uncertainties`, `fixed_lower_boundaries`, and `fixed_upper_boundaries`.
+
 ## 0.5.0
 
 ### Changed

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BuildConstructors"
 uuid = "63b9b590-f22f-4e79-810f-ea9ba6849c26"
 authors = ["Robert Hentges <robert.hentges@cern.ch>"]
-version = "0.5.0"
+version = "0.6.0"
 
 [deps]
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ The package includes a few ready-to-use descriptors:
 The same generic tools work recursively on constructors and nested constructors:
 
 ```julia
+metadata = parameter_metadata(c)
 parameter_values(c)
 parameter_names(c)
 running_names(c)

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ fixed_names(c)
 parameter_uncertainties(c)
 parameter_lower_boundaries(c)
 parameter_upper_boundaries(c)
+running_values(c)
+fixed_values(c)
 
 fix!(c, (:σ,))
 release!(c, (:σ,))

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Everything else is convenience:
 | Layer | Essential? | Why it exists |
 | --- | --- | --- |
 | `Fixed`, `Running`, `FlexibleParameter`, `AdvancedParameter` | Useful defaults | Common descriptor types for fixed/free parameters, defaults, bounds, and uncertainties. |
-| `running_values`, `fix!`, `release!`, `update!` | Convenience | Recursive tools for collecting and mutating metadata in nested constructors. |
+| `parameter_values`, `fix!`, `release!`, `update!` | Convenience | Recursive tools for collecting and mutating metadata in nested constructors. |
 | `@with_parameters` | Convenience | Removes boilerplate when a constructor mostly maps parameter descriptors into a `build_model` body. |
 | `serialize` / `deserialize` / `register!` | Optional | Save and restore constructor descriptions through JSON or database-like workflows. |
 | PRB model constructors and loaders | Optional example | Domain-specific probability-model utilities built with the same general mechanism. |
@@ -82,7 +82,7 @@ end
 
 c = ConstructorOfNormalModel(Fixed(0.0), Running("σ"))
 
-running_values(c)        # (σ = missing,)
+parameter_values(c)      # (σ = missing,)
 model = build_model(c, (σ = 0.2,))
 ```
 
@@ -105,10 +105,10 @@ The package includes a few ready-to-use descriptors:
 The same generic tools work recursively on constructors and nested constructors:
 
 ```julia
-running_values(c)
-running_uncertainties(c)
-running_lower_boundaries(c)
-running_upper_boundaries(c)
+parameter_values(c)
+parameter_uncertainties(c)
+parameter_lower_boundaries(c)
+parameter_upper_boundaries(c)
 
 fix!(c, (:σ,))
 release!(c, (:σ,))

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The package includes a few ready-to-use descriptors:
 
 | Descriptor | Use |
 | --- | --- |
-| `Fixed(value)` | A constant value that is not collected as a running parameter. |
+| `Fixed(value)` | A constant value that is not collected as a named parameter. |
 | `Running(name)` | A free parameter read from `pars` by name. |
 | `FlexibleParameter(name, value)` | A parameter with a stored value that can be fixed or released. |
 | `AdvancedParameter(name, value; boundaries, uncertainty)` | A parameter with a stored value, bounds, uncertainty, and fixed/free state. |
@@ -106,6 +106,9 @@ The same generic tools work recursively on constructors and nested constructors:
 
 ```julia
 parameter_values(c)
+parameter_names(c)
+running_names(c)
+fixed_names(c)
 parameter_uncertainties(c)
 parameter_lower_boundaries(c)
 parameter_upper_boundaries(c)

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ release!(c, (:σ,))
 update!(c, (σ = 0.25,))
 ```
 
+When names are duplicated, metadata preserves every entry, while projected collectors keep one key and use the last value.
+
 You can define your own parameter descriptor by subtyping
 `BuildConstructors.AbstractParameter` and implementing `BuildConstructors.value`.
 Implement the other methods only if your descriptor needs to participate in fixing,

--- a/docs/example1.jl
+++ b/docs/example1.jl
@@ -43,7 +43,7 @@ c = ConstructorOfComb(
 )
 
 # let's see what parameters are running, if there are good default values
-running_values(c)
+parameter_values(c)
 
 # build a model and plot it
 m = build_model(c, (μ = 1.2, scale = 0.7, m = 1.8718, weight = 0.5))

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -56,6 +56,7 @@ BuildConstructors.FlexibleParameter
 BuildConstructors.AdvancedParameter
 BuildConstructors.AbstractConstructor
 BuildConstructors.build_model
+BuildConstructors.parameter_metadata
 BuildConstructors.parameter_names
 BuildConstructors.running_names
 BuildConstructors.fixed_names

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -63,6 +63,14 @@ BuildConstructors.parameter_values
 BuildConstructors.parameter_uncertainties
 BuildConstructors.parameter_lower_boundaries
 BuildConstructors.parameter_upper_boundaries
+BuildConstructors.running_values
+BuildConstructors.running_uncertainties
+BuildConstructors.running_lower_boundaries
+BuildConstructors.running_upper_boundaries
+BuildConstructors.fixed_values
+BuildConstructors.fixed_uncertainties
+BuildConstructors.fixed_lower_boundaries
+BuildConstructors.fixed_upper_boundaries
 BuildConstructors.fix!
 BuildConstructors.release!
 BuildConstructors.update!

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -56,6 +56,9 @@ BuildConstructors.FlexibleParameter
 BuildConstructors.AdvancedParameter
 BuildConstructors.AbstractConstructor
 BuildConstructors.build_model
+BuildConstructors.parameter_names
+BuildConstructors.running_names
+BuildConstructors.fixed_names
 BuildConstructors.parameter_values
 BuildConstructors.parameter_uncertainties
 BuildConstructors.parameter_lower_boundaries

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -24,7 +24,7 @@ constructor = ConstructorOfGauss(
     AdvancedParameter("σ", 1.0; boundaries = (0.05, 5.0), uncertainty = 0.1),
 )
 
-start = running_values(constructor)
+start = parameter_values(constructor)
 model = build_model(constructor, start)
 ```
 
@@ -56,10 +56,10 @@ BuildConstructors.FlexibleParameter
 BuildConstructors.AdvancedParameter
 BuildConstructors.AbstractConstructor
 BuildConstructors.build_model
-BuildConstructors.running_values
-BuildConstructors.running_uncertainties
-BuildConstructors.running_lower_boundaries
-BuildConstructors.running_upper_boundaries
+BuildConstructors.parameter_values
+BuildConstructors.parameter_uncertainties
+BuildConstructors.parameter_lower_boundaries
+BuildConstructors.parameter_upper_boundaries
 BuildConstructors.fix!
 BuildConstructors.release!
 BuildConstructors.update!

--- a/docs/src/tutorials/minuit2-componentarrays.md
+++ b/docs/src/tutorials/minuit2-componentarrays.md
@@ -47,12 +47,12 @@ data = rand(truth, 2_000)
 Prepare the starting point and metadata:
 
 ```julia
-start = ComponentArray(running_values(constructor))
-lower = ComponentArray(running_lower_boundaries(constructor))
-upper = ComponentArray(running_upper_boundaries(constructor))
+start = ComponentArray(parameter_values(constructor))
+lower = ComponentArray(parameter_lower_boundaries(constructor))
+upper = ComponentArray(parameter_upper_boundaries(constructor))
 
 errors = ComponentArray(
-    map(v -> coalesce(v, 0.1), running_uncertainties(constructor)),
+    map(v -> coalesce(v, 0.1), parameter_uncertainties(constructor)),
 )
 limits = collect(zip(lower, upper))
 ```
@@ -99,7 +99,7 @@ fitted.σ_left
 fitted.f_left
 
 update!(constructor, fitted)
-running_values(constructor)
+parameter_values(constructor)
 ```
 
 The important part is that the objective function itself can remain written in

--- a/docs/src/tutorials/nested-constructors.md
+++ b/docs/src/tutorials/nested-constructors.md
@@ -2,7 +2,7 @@
 
 Nested constructors are the main reason to keep parameter metadata outside the
 model object. A parent constructor can store child constructors, and
-`running_values`, `fix!`, `release!`, `update!`, and `build_model` recurse through
+`parameter_values`, `fix!`, `release!`, `update!`, and `build_model` recurse through
 the full tree.
 
 This example builds a weighted mixture of two normal distributions. The final
@@ -46,17 +46,17 @@ constructor = ConstructorOfMixture(
 The metadata collectors see every parameter in the nested tree:
 
 ```julia
-running_values(constructor)
+parameter_values(constructor)
 # (μ_left = -1.0, σ_left = 0.8, μ_right = 1.2, σ_right = 0.5, f_left = 0.6)
 
-running_lower_boundaries(constructor)
+parameter_lower_boundaries(constructor)
 # (μ_left = -5.0, σ_left = 0.05, μ_right = -5.0, σ_right = 0.05, f_left = 0.0)
 ```
 
 Use the collected values directly to build the model:
 
 ```julia
-pars = running_values(constructor)
+pars = parameter_values(constructor)
 model = build_model(constructor, pars)
 pdf(model, 0.0)
 ```
@@ -65,10 +65,10 @@ Mutating helpers also recurse through the tree:
 
 ```julia
 fix!(constructor, (:σ_left, :σ_right))
-running_values(constructor)
+parameter_values(constructor)
 
 update!(constructor, (μ_left = -0.8, μ_right = 1.0, f_left = 0.55))
-running_values(constructor)
+parameter_values(constructor)
 
 release!(constructor, (:σ_left, :σ_right))
 ```

--- a/docs/src/tutorials/optim-componentarrays.md
+++ b/docs/src/tutorials/optim-componentarrays.md
@@ -49,9 +49,9 @@ data = rand(truth, 2_000)
 Convert the constructor metadata to `ComponentArray`s:
 
 ```julia
-start = ComponentArray(running_values(constructor))
-lower = ComponentArray(running_lower_boundaries(constructor))
-upper = ComponentArray(running_upper_boundaries(constructor))
+start = ComponentArray(parameter_values(constructor))
+lower = ComponentArray(parameter_lower_boundaries(constructor))
+upper = ComponentArray(parameter_upper_boundaries(constructor))
 ```
 
 The negative log-likelihood can pass the `ComponentArray` directly into
@@ -89,7 +89,7 @@ fitted.σ_left
 fitted.f_left
 
 update!(constructor, fitted)
-running_values(constructor)
+parameter_values(constructor)
 ```
 
 This avoids the usual back-and-forth conversion between a flat vector and a

--- a/src/BuildConstructors.jl
+++ b/src/BuildConstructors.jl
@@ -15,6 +15,14 @@ export parameter_values
 export parameter_uncertainties
 export parameter_upper_boundaries
 export parameter_lower_boundaries
+export running_values
+export running_uncertainties
+export running_upper_boundaries
+export running_lower_boundaries
+export fixed_values
+export fixed_uncertainties
+export fixed_upper_boundaries
+export fixed_lower_boundaries
 include("abstract-parameters.jl")
 
 export Fixed

--- a/src/BuildConstructors.jl
+++ b/src/BuildConstructors.jl
@@ -9,6 +9,8 @@ export fix!
 export release!
 export update!
 export running_values
+export released_values
+export fixed_values
 export running_uncertainties
 export running_upper_boundaries
 export running_lower_boundaries

--- a/src/BuildConstructors.jl
+++ b/src/BuildConstructors.jl
@@ -8,11 +8,15 @@ using OrderedCollections
 export fix!
 export release!
 export update!
+export parameter_values
 export running_values
 export released_values
 export fixed_values
+export parameter_uncertainties
 export running_uncertainties
+export parameter_upper_boundaries
 export running_upper_boundaries
+export parameter_lower_boundaries
 export running_lower_boundaries
 include("abstract-parameters.jl")
 

--- a/src/BuildConstructors.jl
+++ b/src/BuildConstructors.jl
@@ -8,6 +8,7 @@ using OrderedCollections
 export fix!
 export release!
 export update!
+export parameter_metadata
 export parameter_names
 export running_names
 export fixed_names

--- a/src/BuildConstructors.jl
+++ b/src/BuildConstructors.jl
@@ -8,16 +8,13 @@ using OrderedCollections
 export fix!
 export release!
 export update!
+export parameter_names
+export running_names
+export fixed_names
 export parameter_values
-export running_values
-export released_values
-export fixed_values
 export parameter_uncertainties
-export running_uncertainties
 export parameter_upper_boundaries
-export running_upper_boundaries
 export parameter_lower_boundaries
-export running_lower_boundaries
 include("abstract-parameters.jl")
 
 export Fixed

--- a/src/abstract-constructor.jl
+++ b/src/abstract-constructor.jl
@@ -5,7 +5,7 @@ Abstract supertype for objects that describe how to build another Julia object.
 
 Subtypes usually store parameter descriptors and any non-parameter configuration
 needed by `build_model`. Generic metadata utilities such as `parameter_values`,
-`released_values`, `fixed_values`, `fix!`, `release!`, and `update!` recurse through fields of
+`parameter_names`, `running_names`, `fixed_names`, `fix!`, `release!`, and `update!` recurse through fields of
 `AbstractConstructor`s, so nested constructors compose naturally.
 """
 abstract type AbstractConstructor end
@@ -36,8 +36,6 @@ end
 # collection functionality
 for func in (
     :parameter_values,
-    :released_values,
-    :fixed_values,
     :parameter_uncertainties,
     :parameter_upper_boundaries,
     :parameter_lower_boundaries,
@@ -46,6 +44,16 @@ for func in (
         _list = NamedTuple()
         for field in fieldnames(typeof(c))
             _list = merge(_list, $func(getfield(c, field)))
+        end
+        return _list
+    end
+end
+
+for func in (:parameter_names, :running_names, :fixed_names)
+    @eval function $func(c::AbstractConstructor)
+        _list = ()
+        for field in fieldnames(typeof(c))
+            _list = (_list..., $func(getfield(c, field))...)
         end
         return _list
     end

--- a/src/abstract-constructor.jl
+++ b/src/abstract-constructor.jl
@@ -5,7 +5,7 @@ Abstract supertype for objects that describe how to build another Julia object.
 
 Subtypes usually store parameter descriptors and any non-parameter configuration
 needed by `build_model`. Generic metadata utilities such as `running_values`,
-`fix!`, `release!`, and `update!` recurse through fields of
+`released_values`, `fixed_values`, `fix!`, `release!`, and `update!` recurse through fields of
 `AbstractConstructor`s, so nested constructors compose naturally.
 """
 abstract type AbstractConstructor end
@@ -36,6 +36,8 @@ end
 # collection functionality
 for func in (
     :running_values,
+    :released_values,
+    :fixed_values,
     :running_uncertainties,
     :running_upper_boundaries,
     :running_lower_boundaries,

--- a/src/abstract-constructor.jl
+++ b/src/abstract-constructor.jl
@@ -4,9 +4,10 @@
 Abstract supertype for objects that describe how to build another Julia object.
 
 Subtypes usually store parameter descriptors and any non-parameter configuration
-needed by `build_model`. Generic metadata utilities such as `parameter_values`,
-`parameter_names`, `running_names`, `fixed_names`, `fix!`, `release!`, and `update!` recurse through fields of
-`AbstractConstructor`s, so nested constructors compose naturally.
+needed by `build_model`. Generic metadata utilities such as `parameter_metadata`,
+`parameter_values`, `parameter_names`, `running_names`, `fixed_names`, `fix!`,
+`release!`, and `update!` recurse through fields of `AbstractConstructor`s, so
+nested constructors compose naturally.
 """
 abstract type AbstractConstructor end
 
@@ -34,27 +35,10 @@ for func in (:fix!, :release!, :update!)
 end
 
 # collection functionality
-for func in (
-    :parameter_values,
-    :parameter_uncertainties,
-    :parameter_upper_boundaries,
-    :parameter_lower_boundaries,
-)
-    @eval function $func(c::AbstractConstructor)
-        _list = NamedTuple()
-        for field in fieldnames(typeof(c))
-            _list = merge(_list, $func(getfield(c, field)))
-        end
-        return _list
-    end
-end
-
-for func in (:parameter_names, :running_names, :fixed_names)
-    @eval function $func(c::AbstractConstructor)
-        _list = ()
-        for field in fieldnames(typeof(c))
-            _list = (_list..., $func(getfield(c, field))...)
-        end
-        return _list
-    end
+function parameter_metadata(c::AbstractConstructor)
+    return (
+        Base.Iterators.flatten(
+            parameter_metadata(getfield(c, field)) for field in fieldnames(typeof(c))
+        )...,
+    )
 end

--- a/src/abstract-constructor.jl
+++ b/src/abstract-constructor.jl
@@ -4,7 +4,7 @@
 Abstract supertype for objects that describe how to build another Julia object.
 
 Subtypes usually store parameter descriptors and any non-parameter configuration
-needed by `build_model`. Generic metadata utilities such as `running_values`,
+needed by `build_model`. Generic metadata utilities such as `parameter_values`,
 `released_values`, `fixed_values`, `fix!`, `release!`, and `update!` recurse through fields of
 `AbstractConstructor`s, so nested constructors compose naturally.
 """
@@ -35,12 +35,12 @@ end
 
 # collection functionality
 for func in (
-    :running_values,
+    :parameter_values,
     :released_values,
     :fixed_values,
-    :running_uncertainties,
-    :running_upper_boundaries,
-    :running_lower_boundaries,
+    :parameter_uncertainties,
+    :parameter_upper_boundaries,
+    :parameter_lower_boundaries,
 )
     @eval function $func(c::AbstractConstructor)
         _list = NamedTuple()

--- a/src/abstract-parameters.jl
+++ b/src/abstract-parameters.jl
@@ -77,7 +77,7 @@ raw constructor tree; projection helpers deduplicate by name.
 """
 parameter_metadata(p::AbstractParameter) = ()
 
-_parameter_metadata_entry(p; name, value, uncertainty = missing, lower = -Inf, upper = Inf, fixed = false) = (
+_parameter_metadata_entry(parameter; name, value, uncertainty = missing, lower = -Inf, upper = Inf, fixed = false) = (
     (
         name = Symbol(name),
         value = value,
@@ -85,8 +85,8 @@ _parameter_metadata_entry(p; name, value, uncertainty = missing, lower = -Inf, u
         lower = lower,
         upper = upper,
         fixed = fixed,
-        parameter = p,
-        parameter_type = typeof(p),
+        parameter = parameter,
+        parameter_type = typeof(parameter),
     ),
 )
 
@@ -125,24 +125,17 @@ function _metadata_names(metadata, state::Symbol)
 end
 
 function _metadata_namedtuple(metadata, field::Symbol, state::Symbol)
-    names = Symbol[]
-    values = Any[]
-    for entry in _metadata_entries(metadata)
+    entries = _metadata_entries(metadata)
+    return foldl(entries; init = NamedTuple()) do acc, entry
         include_entry =
             state === :all ||
             (state === :running && !entry.fixed) ||
             (state === :fixed && entry.fixed)
-        include_entry || continue
-        value = getproperty(entry, field)
-        idx = findfirst(==(entry.name), names)
-        if idx === nothing
-            push!(names, entry.name)
-            push!(values, value)
-        else
-            values[idx] = value
+        if include_entry
+            return merge(acc, NamedTuple{(entry.name,)}((getproperty(entry, field),)))
         end
+        return acc
     end
-    return NamedTuple{Tuple(names)}(Tuple(values))
 end
 
 """

--- a/src/abstract-parameters.jl
+++ b/src/abstract-parameters.jl
@@ -6,9 +6,8 @@ Abstract supertype for parameter descriptors.
 A parameter descriptor is metadata about a numeric value, not necessarily the
 numeric value itself. Subtypes should implement `BuildConstructors.value(p; pars)`
 to define how the number is obtained when a constructor is built. They may also
-implement `fix!`, `release!`, `update!`, `parameter_*` collectors,
-`released_values`, and `fixed_values` when they carry fixed/free state,
-defaults, bounds, or uncertainties.
+implement `fix!`, `release!`, `update!`, `parameter_*` collectors, and name
+collectors when they carry fixed/free state, defaults, bounds, or uncertainties.
 """
 abstract type AbstractParameter end
 
@@ -89,54 +88,73 @@ vals = parameter_values(constructor)
 parameter_values(p::AbstractParameter) = NamedTuple()
 
 """
-    released_values(constructor)
+    parameter_names(constructor)
 
-Get the stored values of all currently released parameters as a `NamedTuple`.
+Get the names of all named parameters as a tuple of symbols.
 
-This is the free-parameter counterpart to `parameter_values`: fixed `FlexibleParameter`
-and `AdvancedParameter` descriptors are omitted, while plain `Running` parameters
-are always included.
-
-# Arguments
-- `constructor`: A constructor object (e.g., `ConstructorOfPRBModel`) or a parameter object
-
-# Returns
-A `NamedTuple` of released parameter names and their current values. Parameters
-without a stored value return `missing`.
-
-# Examples
-```julia
-fix!(constructor, (:m,))
-vals = released_values(constructor)
-# Returns all parameter values except m
-```
-"""
-released_values(p::AbstractParameter) = NamedTuple()
-
-"""
-    fixed_values(constructor)
-
-Get the stored values of all currently fixed named parameters as a `NamedTuple`.
-
-This is the fixed-parameter counterpart to `released_values`: fixed
-`FlexibleParameter` and `AdvancedParameter` descriptors are included, while plain
-`Running` parameters are omitted. `Fixed` descriptors are also omitted because
-they do not carry names.
+The returned tuple can be used to filter `parameter_values`,
+`parameter_uncertainties`, `parameter_upper_boundaries`, or
+`parameter_lower_boundaries`.
 
 # Arguments
 - `constructor`: A constructor object (e.g., `ConstructorOfPRBModel`) or a parameter object
 
 # Returns
-A `NamedTuple` of fixed parameter names and their current stored values.
+A tuple of parameter names as symbols.
+
+# Examples
+```julia
+parameter_names(constructor)
+# Returns (:m, :Γ, :σ, :c1, :fs)
+```
+"""
+parameter_names(p::AbstractParameter) = ()
+
+"""
+    running_names(constructor)
+
+Get the names of all currently running parameters as a tuple of symbols.
+
+This is the free-parameter counterpart to `fixed_names`: fixed
+`FlexibleParameter` and `AdvancedParameter` descriptors are omitted, while plain
+`Running` parameters are always included.
+
+# Arguments
+- `constructor`: A constructor object (e.g., `ConstructorOfPRBModel`) or a parameter object
+
+# Returns
+A tuple of running parameter names as symbols.
 
 # Examples
 ```julia
 fix!(constructor, (:m,))
-vals = fixed_values(constructor)
-# Returns (m = 2.0,) when m is a fixed FlexibleParameter or AdvancedParameter
+running_names(constructor)
+# Returns all parameter names except m
 ```
 """
-fixed_values(p::AbstractParameter) = NamedTuple()
+running_names(p::AbstractParameter) = ()
+
+"""
+    fixed_names(constructor)
+
+Get the names of all currently fixed named parameters as a tuple of symbols.
+
+`Fixed` descriptors are omitted because they do not carry names.
+
+# Arguments
+- `constructor`: A constructor object (e.g., `ConstructorOfPRBModel`) or a parameter object
+
+# Returns
+A tuple of fixed parameter names as symbols.
+
+# Examples
+```julia
+fix!(constructor, (:m,))
+fixed_names(constructor)
+# Returns (:m,) when m is a fixed FlexibleParameter or AdvancedParameter
+```
+"""
+fixed_names(p::AbstractParameter) = ()
 
 """
     parameter_uncertainties(constructor)
@@ -210,17 +228,12 @@ fix!(p, par_names) = nothing
 release!(p, par_names) = nothing
 update!(p, pars) = nothing
 parameter_values(p) = NamedTuple()
-released_values(p) = NamedTuple()
-fixed_values(p) = NamedTuple()
+parameter_names(p) = ()
+running_names(p) = ()
+fixed_names(p) = ()
 parameter_uncertainties(p) = NamedTuple()
 parameter_upper_boundaries(p) = NamedTuple()
 parameter_lower_boundaries(p) = NamedTuple()
-
-# Backward-compatible aliases for the old "running_*" collector names.
-running_values(p) = parameter_values(p)
-running_uncertainties(p) = parameter_uncertainties(p)
-running_upper_boundaries(p) = parameter_upper_boundaries(p)
-running_lower_boundaries(p) = parameter_lower_boundaries(p)
 
 
 """

--- a/src/abstract-parameters.jl
+++ b/src/abstract-parameters.jl
@@ -235,6 +235,70 @@ parameter_uncertainties(p) = NamedTuple()
 parameter_upper_boundaries(p) = NamedTuple()
 parameter_lower_boundaries(p) = NamedTuple()
 
+"""
+    running_values(constructor)
+
+Get values for the currently running parameters by filtering `parameter_values`
+with `running_names`.
+"""
+running_values(p) = NamedTuple{running_names(p)}(parameter_values(p))
+
+"""
+    running_uncertainties(constructor)
+
+Get uncertainties for the currently running parameters by filtering
+`parameter_uncertainties` with `running_names`.
+"""
+running_uncertainties(p) = NamedTuple{running_names(p)}(parameter_uncertainties(p))
+
+"""
+    running_upper_boundaries(constructor)
+
+Get upper boundaries for the currently running parameters by filtering
+`parameter_upper_boundaries` with `running_names`.
+"""
+running_upper_boundaries(p) = NamedTuple{running_names(p)}(parameter_upper_boundaries(p))
+
+"""
+    running_lower_boundaries(constructor)
+
+Get lower boundaries for the currently running parameters by filtering
+`parameter_lower_boundaries` with `running_names`.
+"""
+running_lower_boundaries(p) = NamedTuple{running_names(p)}(parameter_lower_boundaries(p))
+
+"""
+    fixed_values(constructor)
+
+Get values for the currently fixed named parameters by filtering
+`parameter_values` with `fixed_names`.
+"""
+fixed_values(p) = NamedTuple{fixed_names(p)}(parameter_values(p))
+
+"""
+    fixed_uncertainties(constructor)
+
+Get uncertainties for the currently fixed named parameters by filtering
+`parameter_uncertainties` with `fixed_names`.
+"""
+fixed_uncertainties(p) = NamedTuple{fixed_names(p)}(parameter_uncertainties(p))
+
+"""
+    fixed_upper_boundaries(constructor)
+
+Get upper boundaries for the currently fixed named parameters by filtering
+`parameter_upper_boundaries` with `fixed_names`.
+"""
+fixed_upper_boundaries(p) = NamedTuple{fixed_names(p)}(parameter_upper_boundaries(p))
+
+"""
+    fixed_lower_boundaries(constructor)
+
+Get lower boundaries for the currently fixed named parameters by filtering
+`parameter_lower_boundaries` with `fixed_names`.
+"""
+fixed_lower_boundaries(p) = NamedTuple{fixed_names(p)}(parameter_lower_boundaries(p))
+
 
 """
     fix!(constructor)

--- a/src/abstract-parameters.jl
+++ b/src/abstract-parameters.jl
@@ -6,9 +6,9 @@ Abstract supertype for parameter descriptors.
 A parameter descriptor is metadata about a numeric value, not necessarily the
 numeric value itself. Subtypes should implement `BuildConstructors.value(p; pars)`
 to define how the number is obtained when a constructor is built. They may also
-implement `fix!`, `release!`, `update!`, `running_*` collectors, and
-`released_values` / `fixed_values` when they carry fixed/free state, defaults, bounds, or
-uncertainties.
+implement `fix!`, `release!`, `update!`, `parameter_*` collectors,
+`released_values`, and `fixed_values` when they carry fixed/free state,
+defaults, bounds, or uncertainties.
 """
 abstract type AbstractParameter end
 
@@ -67,9 +67,9 @@ update!(constructor.model_p, ComponentArray(m = 1.9, Γ = 0.1))
 update!(p::AbstractParameter, pars) = nothing
 
 """
-    running_values(constructor)
+    parameter_values(constructor)
 
-Get the stored values of all running parameters as a `NamedTuple`. The method is used to collect the starting values.
+Get the stored values of all named parameters as a `NamedTuple`. The method is used to collect the starting values.
 
 Returns a `NamedTuple` where each key is a parameter name.
 
@@ -82,18 +82,18 @@ Parameter without a stored value return `missing`.
 
 # Examples
 ```julia
-vals = running_values(constructor)
+vals = parameter_values(constructor)
 # Returns: (m = 2.0, Γ = 0.2, σ = missing, c1 = 0.3, fs = 0.5)
 ```
 """
-running_values(p::AbstractParameter) = NamedTuple()
+parameter_values(p::AbstractParameter) = NamedTuple()
 
 """
     released_values(constructor)
 
 Get the stored values of all currently released parameters as a `NamedTuple`.
 
-This is the free-parameter counterpart to `running_values`: fixed `FlexibleParameter`
+This is the free-parameter counterpart to `parameter_values`: fixed `FlexibleParameter`
 and `AdvancedParameter` descriptors are omitted, while plain `Running` parameters
 are always included.
 
@@ -108,7 +108,7 @@ without a stored value return `missing`.
 ```julia
 fix!(constructor, (:m,))
 vals = released_values(constructor)
-# Returns all running values except m
+# Returns all parameter values except m
 ```
 """
 released_values(p::AbstractParameter) = NamedTuple()
@@ -139,9 +139,9 @@ vals = fixed_values(constructor)
 fixed_values(p::AbstractParameter) = NamedTuple()
 
 """
-    running_uncertainties(constructor)
+    parameter_uncertainties(constructor)
 
-Get the uncertainties for all running parameters as a `NamedTuple`.
+Get the uncertainties for all named parameters as a `NamedTuple`.
 
 Returns a `NamedTuple` where each key is a parameter name and each value is the parameter's
 uncertainty. Parameters without defined uncertainties return `missing`.
@@ -154,16 +154,16 @@ A `NamedTuple` of parameter names and their uncertainties (or `missing` if not d
 
 # Examples
 ```julia
-unc = running_uncertainties(constructor)
+unc = parameter_uncertainties(constructor)
 # Returns: (m = missing, Γ = missing, σ = missing, c1 = missing, fs = 0.01)
 ```
 """
-running_uncertainties(p::AbstractParameter) = NamedTuple()
+parameter_uncertainties(p::AbstractParameter) = NamedTuple()
 
 """
-    running_upper_boundaries(constructor)
+    parameter_upper_boundaries(constructor)
 
-Get the upper boundaries for all running parameters as a `NamedTuple`.
+Get the upper boundaries for all named parameters as a `NamedTuple`.
 
 Returns a `NamedTuple` where each key is a parameter name.
 Parameters without a stored upper boundary return `Inf`.
@@ -176,16 +176,16 @@ A `NamedTuple` of parameter names and their upper boundaries.
 
 # Examples
 ```julia
-upper = running_upper_boundaries(constructor)
+upper = parameter_upper_boundaries(constructor)
 # Returns: (m = Inf, Γ = Inf, σ = Inf, c1 = Inf, fs = 1.0)
 ```
 """
-running_upper_boundaries(p::AbstractParameter) = NamedTuple()
+parameter_upper_boundaries(p::AbstractParameter) = NamedTuple()
 
 """
-    running_lower_boundaries(constructor)
+    parameter_lower_boundaries(constructor)
 
-Get the lower boundaries for all running parameters as a `NamedTuple`.
+Get the lower boundaries for all named parameters as a `NamedTuple`.
 
 Returns a `NamedTuple` where each key is a parameter name and each value is the parameter's
 lower boundary. Parameters without explicit boundaries return `-Inf`.
@@ -198,23 +198,29 @@ A `NamedTuple` of parameter names and their lower boundaries.
 
 # Examples
 ```julia
-lower = running_lower_boundaries(constructor)
+lower = parameter_lower_boundaries(constructor)
 # Returns: (m = -Inf, Γ = -Inf, σ = -Inf, c1 = -Inf, fs = 0.0)
 ```
 """
-running_lower_boundaries(p::AbstractParameter) = NamedTuple()
+parameter_lower_boundaries(p::AbstractParameter) = NamedTuple()
 
 
 # when applying the methods to any fields it fields, it does nothing 
 fix!(p, par_names) = nothing
 release!(p, par_names) = nothing
 update!(p, pars) = nothing
-running_values(p) = NamedTuple()
+parameter_values(p) = NamedTuple()
 released_values(p) = NamedTuple()
 fixed_values(p) = NamedTuple()
-running_uncertainties(p) = NamedTuple()
-running_upper_boundaries(p) = NamedTuple()
-running_lower_boundaries(p) = NamedTuple()
+parameter_uncertainties(p) = NamedTuple()
+parameter_upper_boundaries(p) = NamedTuple()
+parameter_lower_boundaries(p) = NamedTuple()
+
+# Backward-compatible aliases for the old "running_*" collector names.
+running_values(p) = parameter_values(p)
+running_uncertainties(p) = parameter_uncertainties(p)
+running_upper_boundaries(p) = parameter_upper_boundaries(p)
+running_lower_boundaries(p) = parameter_lower_boundaries(p)
 
 
 """
@@ -230,7 +236,7 @@ Fix all parameters in the constructor so they remain constant during fitting.
 fix!(constructor)  # Fix all parameters
 ```
 """
-fix!(c) = fix!(c, keys(running_values(c)))
+fix!(c) = fix!(c, keys(parameter_values(c)))
 
 """
     release!(constructor)
@@ -245,4 +251,4 @@ Release all parameters in the constructor so they can vary during fitting.
 release!(constructor)  # Release all parameters
 ```
 """
-release!(c) = release!(c, keys(running_values(c)))
+release!(c) = release!(c, keys(parameter_values(c)))

--- a/src/abstract-parameters.jl
+++ b/src/abstract-parameters.jl
@@ -6,8 +6,9 @@ Abstract supertype for parameter descriptors.
 A parameter descriptor is metadata about a numeric value, not necessarily the
 numeric value itself. Subtypes should implement `BuildConstructors.value(p; pars)`
 to define how the number is obtained when a constructor is built. They may also
-implement `fix!`, `release!`, `update!`, and the `running_*` collectors when they
-carry fixed/free state, defaults, bounds, or uncertainties.
+implement `fix!`, `release!`, `update!`, `running_*` collectors, and
+`released_values` / `fixed_values` when they carry fixed/free state, defaults, bounds, or
+uncertainties.
 """
 abstract type AbstractParameter end
 
@@ -88,6 +89,56 @@ vals = running_values(constructor)
 running_values(p::AbstractParameter) = NamedTuple()
 
 """
+    released_values(constructor)
+
+Get the stored values of all currently released parameters as a `NamedTuple`.
+
+This is the free-parameter counterpart to `running_values`: fixed `FlexibleParameter`
+and `AdvancedParameter` descriptors are omitted, while plain `Running` parameters
+are always included.
+
+# Arguments
+- `constructor`: A constructor object (e.g., `ConstructorOfPRBModel`) or a parameter object
+
+# Returns
+A `NamedTuple` of released parameter names and their current values. Parameters
+without a stored value return `missing`.
+
+# Examples
+```julia
+fix!(constructor, (:m,))
+vals = released_values(constructor)
+# Returns all running values except m
+```
+"""
+released_values(p::AbstractParameter) = NamedTuple()
+
+"""
+    fixed_values(constructor)
+
+Get the stored values of all currently fixed named parameters as a `NamedTuple`.
+
+This is the fixed-parameter counterpart to `released_values`: fixed
+`FlexibleParameter` and `AdvancedParameter` descriptors are included, while plain
+`Running` parameters are omitted. `Fixed` descriptors are also omitted because
+they do not carry names.
+
+# Arguments
+- `constructor`: A constructor object (e.g., `ConstructorOfPRBModel`) or a parameter object
+
+# Returns
+A `NamedTuple` of fixed parameter names and their current stored values.
+
+# Examples
+```julia
+fix!(constructor, (:m,))
+vals = fixed_values(constructor)
+# Returns (m = 2.0,) when m is a fixed FlexibleParameter or AdvancedParameter
+```
+"""
+fixed_values(p::AbstractParameter) = NamedTuple()
+
+"""
     running_uncertainties(constructor)
 
 Get the uncertainties for all running parameters as a `NamedTuple`.
@@ -159,6 +210,8 @@ fix!(p, par_names) = nothing
 release!(p, par_names) = nothing
 update!(p, pars) = nothing
 running_values(p) = NamedTuple()
+released_values(p) = NamedTuple()
+fixed_values(p) = NamedTuple()
 running_uncertainties(p) = NamedTuple()
 running_upper_boundaries(p) = NamedTuple()
 running_lower_boundaries(p) = NamedTuple()

--- a/src/abstract-parameters.jl
+++ b/src/abstract-parameters.jl
@@ -66,238 +66,195 @@ update!(constructor.model_p, ComponentArray(m = 1.9, Γ = 0.1))
 update!(p::AbstractParameter, pars) = nothing
 
 """
+    parameter_metadata(constructor)
+
+Collect all named parameter descriptors as metadata entries.
+
+Each entry is a `NamedTuple` with fields:
+`name`, `value`, `uncertainty`, `lower`, `upper`, `fixed`, `parameter`, and
+`parameter_type`. Duplicate names are preserved here so callers can inspect the
+raw constructor tree; projection helpers deduplicate by name.
+"""
+parameter_metadata(p::AbstractParameter) = ()
+
+_parameter_metadata_entry(p; name, value, uncertainty = missing, lower = -Inf, upper = Inf, fixed = false) = (
+    (
+        name = Symbol(name),
+        value = value,
+        uncertainty = uncertainty,
+        lower = lower,
+        upper = upper,
+        fixed = fixed,
+        parameter = p,
+        parameter_type = typeof(p),
+    ),
+)
+
+const _PARAMETER_METADATA_KEYS = (
+    :name,
+    :value,
+    :uncertainty,
+    :lower,
+    :upper,
+    :fixed,
+    :parameter,
+    :parameter_type,
+)
+
+_is_parameter_metadata_entry(entry) =
+    entry isa NamedTuple && all(key -> key in keys(entry), _PARAMETER_METADATA_KEYS)
+
+_is_parameter_metadata(metadata::Tuple) = all(_is_parameter_metadata_entry, metadata)
+
+function _metadata_entries(p)
+    metadata = p isa Tuple && _is_parameter_metadata(p) ? p : parameter_metadata(p)
+    return _is_parameter_metadata(metadata) ? metadata : ()
+end
+
+function _metadata_names(metadata, state::Symbol)
+    names = Symbol[]
+    for entry in _metadata_entries(metadata)
+        include_entry =
+            state === :all ||
+            (state === :running && !entry.fixed) ||
+            (state === :fixed && entry.fixed)
+        include_entry || continue
+        entry.name in names || push!(names, entry.name)
+    end
+    return Tuple(names)
+end
+
+function _metadata_namedtuple(metadata, field::Symbol, state::Symbol)
+    names = Symbol[]
+    values = Any[]
+    for entry in _metadata_entries(metadata)
+        include_entry =
+            state === :all ||
+            (state === :running && !entry.fixed) ||
+            (state === :fixed && entry.fixed)
+        include_entry || continue
+        value = getproperty(entry, field)
+        idx = findfirst(==(entry.name), names)
+        if idx === nothing
+            push!(names, entry.name)
+            push!(values, value)
+        else
+            values[idx] = value
+        end
+    end
+    return NamedTuple{Tuple(names)}(Tuple(values))
+end
+
+"""
     parameter_values(constructor)
 
-Get the stored values of all named parameters as a `NamedTuple`. The method is used to collect the starting values.
-
-Returns a `NamedTuple` where each key is a parameter name.
-
-# Arguments
-- `constructor`: A constructor object (e.g., `ConstructorOfPRBModel`) or a parameter object
-
-# Returns
-A `NamedTuple` of parameter names and their current values.
-Parameter without a stored value return `missing`.
-
-# Examples
-```julia
-vals = parameter_values(constructor)
-# Returns: (m = 2.0, Γ = 0.2, σ = missing, c1 = 0.3, fs = 0.5)
-```
+Get the stored values of all named parameters as a `NamedTuple`.
 """
-parameter_values(p::AbstractParameter) = NamedTuple()
+parameter_values(p) = _metadata_namedtuple(p, :value, :all)
 
 """
     parameter_names(constructor)
 
 Get the names of all named parameters as a tuple of symbols.
-
-The returned tuple can be used to filter `parameter_values`,
-`parameter_uncertainties`, `parameter_upper_boundaries`, or
-`parameter_lower_boundaries`.
-
-# Arguments
-- `constructor`: A constructor object (e.g., `ConstructorOfPRBModel`) or a parameter object
-
-# Returns
-A tuple of parameter names as symbols.
-
-# Examples
-```julia
-parameter_names(constructor)
-# Returns (:m, :Γ, :σ, :c1, :fs)
-```
 """
-parameter_names(p::AbstractParameter) = ()
+parameter_names(p) = _metadata_names(p, :all)
 
 """
     running_names(constructor)
 
 Get the names of all currently running parameters as a tuple of symbols.
-
-This is the free-parameter counterpart to `fixed_names`: fixed
-`FlexibleParameter` and `AdvancedParameter` descriptors are omitted, while plain
-`Running` parameters are always included.
-
-# Arguments
-- `constructor`: A constructor object (e.g., `ConstructorOfPRBModel`) or a parameter object
-
-# Returns
-A tuple of running parameter names as symbols.
-
-# Examples
-```julia
-fix!(constructor, (:m,))
-running_names(constructor)
-# Returns all parameter names except m
-```
 """
-running_names(p::AbstractParameter) = ()
+running_names(p) = _metadata_names(p, :running)
 
 """
     fixed_names(constructor)
 
 Get the names of all currently fixed named parameters as a tuple of symbols.
-
-`Fixed` descriptors are omitted because they do not carry names.
-
-# Arguments
-- `constructor`: A constructor object (e.g., `ConstructorOfPRBModel`) or a parameter object
-
-# Returns
-A tuple of fixed parameter names as symbols.
-
-# Examples
-```julia
-fix!(constructor, (:m,))
-fixed_names(constructor)
-# Returns (:m,) when m is a fixed FlexibleParameter or AdvancedParameter
-```
 """
-fixed_names(p::AbstractParameter) = ()
+fixed_names(p) = _metadata_names(p, :fixed)
 
 """
     parameter_uncertainties(constructor)
 
 Get the uncertainties for all named parameters as a `NamedTuple`.
-
-Returns a `NamedTuple` where each key is a parameter name and each value is the parameter's
-uncertainty. Parameters without defined uncertainties return `missing`.
-
-# Arguments
-- `constructor`: A constructor object (e.g., `ConstructorOfPRBModel`) or a parameter object
-
-# Returns
-A `NamedTuple` of parameter names and their uncertainties (or `missing` if not defined).
-
-# Examples
-```julia
-unc = parameter_uncertainties(constructor)
-# Returns: (m = missing, Γ = missing, σ = missing, c1 = missing, fs = 0.01)
-```
 """
-parameter_uncertainties(p::AbstractParameter) = NamedTuple()
+parameter_uncertainties(p) = _metadata_namedtuple(p, :uncertainty, :all)
 
 """
     parameter_upper_boundaries(constructor)
 
 Get the upper boundaries for all named parameters as a `NamedTuple`.
-
-Returns a `NamedTuple` where each key is a parameter name.
-Parameters without a stored upper boundary return `Inf`.
-
-# Arguments
-- `constructor`: A constructor object (e.g., `ConstructorOfPRBModel`) or a parameter object
-
-# Returns
-A `NamedTuple` of parameter names and their upper boundaries.
-
-# Examples
-```julia
-upper = parameter_upper_boundaries(constructor)
-# Returns: (m = Inf, Γ = Inf, σ = Inf, c1 = Inf, fs = 1.0)
-```
 """
-parameter_upper_boundaries(p::AbstractParameter) = NamedTuple()
+parameter_upper_boundaries(p) = _metadata_namedtuple(p, :upper, :all)
 
 """
     parameter_lower_boundaries(constructor)
 
 Get the lower boundaries for all named parameters as a `NamedTuple`.
-
-Returns a `NamedTuple` where each key is a parameter name and each value is the parameter's
-lower boundary. Parameters without explicit boundaries return `-Inf`.
-
-# Arguments
-- `constructor`: A constructor object (e.g., `ConstructorOfPRBModel`) or a parameter object
-
-# Returns
-A `NamedTuple` of parameter names and their lower boundaries.
-
-# Examples
-```julia
-lower = parameter_lower_boundaries(constructor)
-# Returns: (m = -Inf, Γ = -Inf, σ = -Inf, c1 = -Inf, fs = 0.0)
-```
 """
-parameter_lower_boundaries(p::AbstractParameter) = NamedTuple()
+parameter_lower_boundaries(p) = _metadata_namedtuple(p, :lower, :all)
 
 
 # when applying the methods to any fields it fields, it does nothing 
 fix!(p, par_names) = nothing
 release!(p, par_names) = nothing
 update!(p, pars) = nothing
-parameter_values(p) = NamedTuple()
-parameter_names(p) = ()
-running_names(p) = ()
-fixed_names(p) = ()
-parameter_uncertainties(p) = NamedTuple()
-parameter_upper_boundaries(p) = NamedTuple()
-parameter_lower_boundaries(p) = NamedTuple()
-
+parameter_metadata(p) = ()
 """
     running_values(constructor)
 
-Get values for the currently running parameters by filtering `parameter_values`
-with `running_names`.
+Get values for the currently running parameters.
 """
-running_values(p) = NamedTuple{running_names(p)}(parameter_values(p))
+running_values(p) = _metadata_namedtuple(p, :value, :running)
 
 """
     running_uncertainties(constructor)
 
-Get uncertainties for the currently running parameters by filtering
-`parameter_uncertainties` with `running_names`.
+Get uncertainties for the currently running parameters.
 """
-running_uncertainties(p) = NamedTuple{running_names(p)}(parameter_uncertainties(p))
+running_uncertainties(p) = _metadata_namedtuple(p, :uncertainty, :running)
 
 """
     running_upper_boundaries(constructor)
 
-Get upper boundaries for the currently running parameters by filtering
-`parameter_upper_boundaries` with `running_names`.
+Get upper boundaries for the currently running parameters.
 """
-running_upper_boundaries(p) = NamedTuple{running_names(p)}(parameter_upper_boundaries(p))
+running_upper_boundaries(p) = _metadata_namedtuple(p, :upper, :running)
 
 """
     running_lower_boundaries(constructor)
 
-Get lower boundaries for the currently running parameters by filtering
-`parameter_lower_boundaries` with `running_names`.
+Get lower boundaries for the currently running parameters.
 """
-running_lower_boundaries(p) = NamedTuple{running_names(p)}(parameter_lower_boundaries(p))
+running_lower_boundaries(p) = _metadata_namedtuple(p, :lower, :running)
 
 """
     fixed_values(constructor)
 
-Get values for the currently fixed named parameters by filtering
-`parameter_values` with `fixed_names`.
+Get values for the currently fixed named parameters.
 """
-fixed_values(p) = NamedTuple{fixed_names(p)}(parameter_values(p))
+fixed_values(p) = _metadata_namedtuple(p, :value, :fixed)
 
 """
     fixed_uncertainties(constructor)
 
-Get uncertainties for the currently fixed named parameters by filtering
-`parameter_uncertainties` with `fixed_names`.
+Get uncertainties for the currently fixed named parameters.
 """
-fixed_uncertainties(p) = NamedTuple{fixed_names(p)}(parameter_uncertainties(p))
+fixed_uncertainties(p) = _metadata_namedtuple(p, :uncertainty, :fixed)
 
 """
     fixed_upper_boundaries(constructor)
 
-Get upper boundaries for the currently fixed named parameters by filtering
-`parameter_upper_boundaries` with `fixed_names`.
+Get upper boundaries for the currently fixed named parameters.
 """
-fixed_upper_boundaries(p) = NamedTuple{fixed_names(p)}(parameter_upper_boundaries(p))
+fixed_upper_boundaries(p) = _metadata_namedtuple(p, :upper, :fixed)
 
 """
     fixed_lower_boundaries(constructor)
 
-Get lower boundaries for the currently fixed named parameters by filtering
-`parameter_lower_boundaries` with `fixed_names`.
+Get lower boundaries for the currently fixed named parameters.
 """
-fixed_lower_boundaries(p) = NamedTuple{fixed_names(p)}(parameter_lower_boundaries(p))
+fixed_lower_boundaries(p) = _metadata_namedtuple(p, :lower, :fixed)
 
 
 """

--- a/src/abstract-parameters.jl
+++ b/src/abstract-parameters.jl
@@ -114,28 +114,33 @@ end
 function _metadata_names(metadata, state::Symbol)
     names = Symbol[]
     for entry in _metadata_entries(metadata)
-        include_entry =
-            state === :all ||
-            (state === :running && !entry.fixed) ||
-            (state === :fixed && entry.fixed)
-        include_entry || continue
+        _include_metadata_entry(entry, state) || continue
         entry.name in names || push!(names, entry.name)
     end
     return Tuple(names)
 end
 
+_include_metadata_entry(entry, state::Symbol) =
+    state === :all ||
+    (state === :running && !entry.fixed) ||
+    (state === :fixed && entry.fixed)
+
 function _metadata_namedtuple(metadata, field::Symbol, state::Symbol)
-    entries = _metadata_entries(metadata)
-    return foldl(entries; init = NamedTuple()) do acc, entry
-        include_entry =
-            state === :all ||
-            (state === :running && !entry.fixed) ||
-            (state === :fixed && entry.fixed)
-        if include_entry
-            return merge(acc, NamedTuple{(entry.name,)}((getproperty(entry, field),)))
+    names = Symbol[]
+    values = Any[]
+    for entry in _metadata_entries(metadata)
+        _include_metadata_entry(entry, state) || continue
+
+        name_index = findfirst(==(entry.name), names)
+        value = getproperty(entry, field)
+        if isnothing(name_index)
+            push!(names, entry.name)
+            push!(values, value)
+        else
+            values[name_index] = value
         end
-        return acc
     end
+    return NamedTuple{Tuple(names)}(Tuple(values))
 end
 
 """

--- a/src/abstract-parameters.jl
+++ b/src/abstract-parameters.jl
@@ -102,7 +102,7 @@ const _PARAMETER_METADATA_KEYS = (
 )
 
 _is_parameter_metadata_entry(entry) =
-    entry isa NamedTuple && all(key -> key in keys(entry), _PARAMETER_METADATA_KEYS)
+    entry isa NamedTuple && keys(entry) == _PARAMETER_METADATA_KEYS
 
 _is_parameter_metadata(metadata::Tuple) = all(_is_parameter_metadata_entry, metadata)
 

--- a/src/concrete-parameters.jl
+++ b/src/concrete-parameters.jl
@@ -48,6 +48,13 @@ Resolve a running parameter by reading `Symbol(p.name)` from `pars`.
 value(p::Running; pars) = getproperty(pars, Symbol(p.name))
 
 """
+    parameter_metadata(p::Running)
+
+Return metadata for a plain running parameter.
+"""
+parameter_metadata(c::Running) = _parameter_metadata_entry(c; name = c.name, value = missing)
+
+"""
     parameter_values(p::Running)
 
 Return a one-entry `NamedTuple` for the running parameter name, with `missing` as
@@ -157,6 +164,14 @@ function update!(c::FlexibleParameter, pars)
     hasproperty(pars, sym) && (c.value = getproperty(pars, sym))
     return nothing
 end
+
+"""
+    parameter_metadata(p::FlexibleParameter)
+
+Return metadata for a flexible parameter, including its fixed/free state.
+"""
+parameter_metadata(c::FlexibleParameter) =
+    _parameter_metadata_entry(c; name = c.name, value = c.value, fixed = c.fixed)
 
 """
     parameter_values(p::FlexibleParameter)
@@ -272,6 +287,22 @@ function update!(c::AdvancedParameter, pars)
     hasproperty(pars, sym) && (c.value = getproperty(pars, sym))
     return nothing
 end
+
+"""
+    parameter_metadata(p::AdvancedParameter)
+
+Return metadata for an advanced parameter, including bounds, uncertainty, and
+fixed/free state.
+"""
+parameter_metadata(c::AdvancedParameter) = _parameter_metadata_entry(
+    c;
+    name = c.name,
+    value = c.value,
+    uncertainty = c.uncertainty,
+    lower = c.boundaries[1],
+    upper = c.boundaries[2],
+    fixed = c.fixed,
+)
 
 """
     parameter_values(p::AdvancedParameter)

--- a/src/concrete-parameters.jl
+++ b/src/concrete-parameters.jl
@@ -56,20 +56,26 @@ the value because `Running` stores no default.
 parameter_values(c::Running) = NamedTuple{(Symbol(c.name),)}((missing,))
 
 """
-    released_values(p::Running)
+    parameter_names(p::Running)
 
-Return a one-entry `NamedTuple` for the running parameter name. Plain `Running`
-parameters are always released.
+Return the running parameter name as a one-element tuple of symbols.
 """
-released_values(c::Running) = parameter_values(c)
+parameter_names(c::Running) = (Symbol(c.name),)
 
 """
-    fixed_values(p::Running)
+    running_names(p::Running)
 
-Return an empty `NamedTuple` because plain `Running` parameters are always
-released.
+Return the running parameter name as a one-element tuple of symbols. Plain
+`Running` parameters are always running.
 """
-fixed_values(c::Running) = NamedTuple()
+running_names(c::Running) = parameter_names(c)
+
+"""
+    fixed_names(p::Running)
+
+Return an empty tuple because plain `Running` parameters are always running.
+"""
+fixed_names(c::Running) = ()
 
 """
     parameter_uncertainties(p::Running)
@@ -160,18 +166,25 @@ Return the stored value for this parameter, whether it is currently fixed or fre
 parameter_values(c::FlexibleParameter) = NamedTuple{(Symbol(c.name),)}((c.value,))
 
 """
-    released_values(p::FlexibleParameter)
+    parameter_names(p::FlexibleParameter)
 
-Return the stored value only when this parameter is currently free.
+Return this parameter name as a one-element tuple of symbols.
 """
-released_values(c::FlexibleParameter) = c.fixed ? NamedTuple() : parameter_values(c)
+parameter_names(c::FlexibleParameter) = (Symbol(c.name),)
 
 """
-    fixed_values(p::FlexibleParameter)
+    running_names(p::FlexibleParameter)
 
-Return the stored value only when this parameter is currently fixed.
+Return this parameter name only when this parameter is currently free.
 """
-fixed_values(c::FlexibleParameter) = c.fixed ? parameter_values(c) : NamedTuple()
+running_names(c::FlexibleParameter) = c.fixed ? () : parameter_names(c)
+
+"""
+    fixed_names(p::FlexibleParameter)
+
+Return this parameter name only when this parameter is currently fixed.
+"""
+fixed_names(c::FlexibleParameter) = c.fixed ? parameter_names(c) : ()
 
 """
     parameter_uncertainties(p::FlexibleParameter)
@@ -268,18 +281,25 @@ Return the stored value for this parameter.
 parameter_values(c::AdvancedParameter) = NamedTuple{(Symbol(c.name),)}((c.value,))
 
 """
-    released_values(p::AdvancedParameter)
+    parameter_names(p::AdvancedParameter)
 
-Return the stored value only when this parameter is currently free.
+Return this parameter name as a one-element tuple of symbols.
 """
-released_values(c::AdvancedParameter) = c.fixed ? NamedTuple() : parameter_values(c)
+parameter_names(c::AdvancedParameter) = (Symbol(c.name),)
 
 """
-    fixed_values(p::AdvancedParameter)
+    running_names(p::AdvancedParameter)
 
-Return the stored value only when this parameter is currently fixed.
+Return this parameter name only when this parameter is currently free.
 """
-fixed_values(c::AdvancedParameter) = c.fixed ? parameter_values(c) : NamedTuple()
+running_names(c::AdvancedParameter) = c.fixed ? () : parameter_names(c)
+
+"""
+    fixed_names(p::AdvancedParameter)
+
+Return this parameter name only when this parameter is currently fixed.
+"""
+fixed_names(c::AdvancedParameter) = c.fixed ? parameter_names(c) : ()
 
 """
     parameter_uncertainties(p::AdvancedParameter)

--- a/src/concrete-parameters.jl
+++ b/src/concrete-parameters.jl
@@ -56,6 +56,22 @@ the value because `Running` stores no default.
 running_values(c::Running) = NamedTuple{(Symbol(c.name),)}((missing,))
 
 """
+    released_values(p::Running)
+
+Return a one-entry `NamedTuple` for the running parameter name. Plain `Running`
+parameters are always released.
+"""
+released_values(c::Running) = running_values(c)
+
+"""
+    fixed_values(p::Running)
+
+Return an empty `NamedTuple` because plain `Running` parameters are always
+released.
+"""
+fixed_values(c::Running) = NamedTuple()
+
+"""
     running_uncertainties(p::Running)
 
 Return `missing` uncertainty metadata for a plain `Running` parameter.
@@ -142,6 +158,20 @@ end
 Return the stored value for this parameter, whether it is currently fixed or free.
 """
 running_values(c::FlexibleParameter) = NamedTuple{(Symbol(c.name),)}((c.value,))
+
+"""
+    released_values(p::FlexibleParameter)
+
+Return the stored value only when this parameter is currently free.
+"""
+released_values(c::FlexibleParameter) = c.fixed ? NamedTuple() : running_values(c)
+
+"""
+    fixed_values(p::FlexibleParameter)
+
+Return the stored value only when this parameter is currently fixed.
+"""
+fixed_values(c::FlexibleParameter) = c.fixed ? running_values(c) : NamedTuple()
 
 """
     running_uncertainties(p::FlexibleParameter)
@@ -236,6 +266,20 @@ end
 Return the stored value for this parameter.
 """
 running_values(c::AdvancedParameter) = NamedTuple{(Symbol(c.name),)}((c.value,))
+
+"""
+    released_values(p::AdvancedParameter)
+
+Return the stored value only when this parameter is currently free.
+"""
+released_values(c::AdvancedParameter) = c.fixed ? NamedTuple() : running_values(c)
+
+"""
+    fixed_values(p::AdvancedParameter)
+
+Return the stored value only when this parameter is currently fixed.
+"""
+fixed_values(c::AdvancedParameter) = c.fixed ? running_values(c) : NamedTuple()
 
 """
     running_uncertainties(p::AdvancedParameter)

--- a/src/concrete-parameters.jl
+++ b/src/concrete-parameters.jl
@@ -6,7 +6,7 @@
 
 Parameter descriptor that always resolves to the stored numeric `value`.
 
-`Fixed` parameters are intentionally absent from `running_values` and related
+`Fixed` parameters are intentionally absent from `parameter_values` and related
 metadata collectors, because they are not expected to be supplied by a fitting or
 optimization backend.
 """
@@ -33,7 +33,7 @@ value(p::Fixed; pars) = p.value
 Parameter descriptor for a free parameter read from `pars` by name.
 
 For example, `Running("σ")` resolves with `getproperty(pars, :σ)`. It is collected
-by `running_values` with a `missing` value, signalling that no default is stored
+by `parameter_values` with a `missing` value, signalling that no default is stored
 inside the descriptor.
 """
 struct Running <: AbstractParameter
@@ -48,12 +48,12 @@ Resolve a running parameter by reading `Symbol(p.name)` from `pars`.
 value(p::Running; pars) = getproperty(pars, Symbol(p.name))
 
 """
-    running_values(p::Running)
+    parameter_values(p::Running)
 
 Return a one-entry `NamedTuple` for the running parameter name, with `missing` as
 the value because `Running` stores no default.
 """
-running_values(c::Running) = NamedTuple{(Symbol(c.name),)}((missing,))
+parameter_values(c::Running) = NamedTuple{(Symbol(c.name),)}((missing,))
 
 """
     released_values(p::Running)
@@ -61,7 +61,7 @@ running_values(c::Running) = NamedTuple{(Symbol(c.name),)}((missing,))
 Return a one-entry `NamedTuple` for the running parameter name. Plain `Running`
 parameters are always released.
 """
-released_values(c::Running) = running_values(c)
+released_values(c::Running) = parameter_values(c)
 
 """
     fixed_values(p::Running)
@@ -72,25 +72,25 @@ released.
 fixed_values(c::Running) = NamedTuple()
 
 """
-    running_uncertainties(p::Running)
+    parameter_uncertainties(p::Running)
 
 Return `missing` uncertainty metadata for a plain `Running` parameter.
 """
-running_uncertainties(p::Running) = NamedTuple{(Symbol(p.name),)}((missing,))
+parameter_uncertainties(p::Running) = NamedTuple{(Symbol(p.name),)}((missing,))
 
 """
-    running_upper_boundaries(p::Running)
+    parameter_upper_boundaries(p::Running)
 
 Return `Inf` as the default upper boundary for a plain `Running` parameter.
 """
-running_upper_boundaries(c::Running) = NamedTuple{(Symbol(c.name),)}((Inf,))
+parameter_upper_boundaries(c::Running) = NamedTuple{(Symbol(c.name),)}((Inf,))
 
 """
-    running_lower_boundaries(p::Running)
+    parameter_lower_boundaries(p::Running)
 
 Return `-Inf` as the default lower boundary for a plain `Running` parameter.
 """
-running_lower_boundaries(c::Running) = NamedTuple{(Symbol(c.name),)}((-Inf,))
+parameter_lower_boundaries(c::Running) = NamedTuple{(Symbol(c.name),)}((-Inf,))
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -153,46 +153,46 @@ function update!(c::FlexibleParameter, pars)
 end
 
 """
-    running_values(p::FlexibleParameter)
+    parameter_values(p::FlexibleParameter)
 
 Return the stored value for this parameter, whether it is currently fixed or free.
 """
-running_values(c::FlexibleParameter) = NamedTuple{(Symbol(c.name),)}((c.value,))
+parameter_values(c::FlexibleParameter) = NamedTuple{(Symbol(c.name),)}((c.value,))
 
 """
     released_values(p::FlexibleParameter)
 
 Return the stored value only when this parameter is currently free.
 """
-released_values(c::FlexibleParameter) = c.fixed ? NamedTuple() : running_values(c)
+released_values(c::FlexibleParameter) = c.fixed ? NamedTuple() : parameter_values(c)
 
 """
     fixed_values(p::FlexibleParameter)
 
 Return the stored value only when this parameter is currently fixed.
 """
-fixed_values(c::FlexibleParameter) = c.fixed ? running_values(c) : NamedTuple()
+fixed_values(c::FlexibleParameter) = c.fixed ? parameter_values(c) : NamedTuple()
 
 """
-    running_uncertainties(p::FlexibleParameter)
+    parameter_uncertainties(p::FlexibleParameter)
 
 Return `missing` uncertainty metadata for a flexible parameter.
 """
-running_uncertainties(p::FlexibleParameter) = NamedTuple{(Symbol(p.name),)}((missing,))
+parameter_uncertainties(p::FlexibleParameter) = NamedTuple{(Symbol(p.name),)}((missing,))
 
 """
-    running_upper_boundaries(p::FlexibleParameter)
+    parameter_upper_boundaries(p::FlexibleParameter)
 
 Return `Inf` as the default upper boundary for a flexible parameter.
 """
-running_upper_boundaries(p::FlexibleParameter) = NamedTuple{(Symbol(p.name),)}((Inf,))
+parameter_upper_boundaries(p::FlexibleParameter) = NamedTuple{(Symbol(p.name),)}((Inf,))
 
 """
-    running_lower_boundaries(p::FlexibleParameter)
+    parameter_lower_boundaries(p::FlexibleParameter)
 
 Return `-Inf` as the default lower boundary for a flexible parameter.
 """
-running_lower_boundaries(p::FlexibleParameter) = NamedTuple{(Symbol(p.name),)}((-Inf,))
+parameter_lower_boundaries(p::FlexibleParameter) = NamedTuple{(Symbol(p.name),)}((-Inf,))
 
 
 
@@ -207,7 +207,7 @@ fixed/free state.
 
 Like `FlexibleParameter`, it resolves from `pars` while free and from its stored
 value while fixed. The extra metadata is returned by the corresponding
-`running_*` collection functions.
+`parameter_*` collection functions.
 """
 mutable struct AdvancedParameter <: AbstractParameter
     name::String
@@ -261,46 +261,46 @@ function update!(c::AdvancedParameter, pars)
 end
 
 """
-    running_values(p::AdvancedParameter)
+    parameter_values(p::AdvancedParameter)
 
 Return the stored value for this parameter.
 """
-running_values(c::AdvancedParameter) = NamedTuple{(Symbol(c.name),)}((c.value,))
+parameter_values(c::AdvancedParameter) = NamedTuple{(Symbol(c.name),)}((c.value,))
 
 """
     released_values(p::AdvancedParameter)
 
 Return the stored value only when this parameter is currently free.
 """
-released_values(c::AdvancedParameter) = c.fixed ? NamedTuple() : running_values(c)
+released_values(c::AdvancedParameter) = c.fixed ? NamedTuple() : parameter_values(c)
 
 """
     fixed_values(p::AdvancedParameter)
 
 Return the stored value only when this parameter is currently fixed.
 """
-fixed_values(c::AdvancedParameter) = c.fixed ? running_values(c) : NamedTuple()
+fixed_values(c::AdvancedParameter) = c.fixed ? parameter_values(c) : NamedTuple()
 
 """
-    running_uncertainties(p::AdvancedParameter)
+    parameter_uncertainties(p::AdvancedParameter)
 
 Return the stored uncertainty for this parameter.
 """
-running_uncertainties(p::AdvancedParameter) =
+parameter_uncertainties(p::AdvancedParameter) =
     NamedTuple{(Symbol(p.name),)}((p.uncertainty,))
 
 """
-    running_upper_boundaries(p::AdvancedParameter)
+    parameter_upper_boundaries(p::AdvancedParameter)
 
 Return the upper boundary stored in `p.boundaries[2]`.
 """
-running_upper_boundaries(p::AdvancedParameter) =
+parameter_upper_boundaries(p::AdvancedParameter) =
     NamedTuple{(Symbol(p.name),)}((p.boundaries[2],))
 
 """
-    running_lower_boundaries(p::AdvancedParameter)
+    parameter_lower_boundaries(p::AdvancedParameter)
 
 Return the lower boundary stored in `p.boundaries[1]`.
 """
-running_lower_boundaries(p::AdvancedParameter) =
+parameter_lower_boundaries(p::AdvancedParameter) =
     NamedTuple{(Symbol(p.name),)}((p.boundaries[1],))

--- a/src/concrete-parameters.jl
+++ b/src/concrete-parameters.jl
@@ -54,58 +54,6 @@ Return metadata for a plain running parameter.
 """
 parameter_metadata(c::Running) = _parameter_metadata_entry(c; name = c.name, value = missing)
 
-"""
-    parameter_values(p::Running)
-
-Return a one-entry `NamedTuple` for the running parameter name, with `missing` as
-the value because `Running` stores no default.
-"""
-parameter_values(c::Running) = NamedTuple{(Symbol(c.name),)}((missing,))
-
-"""
-    parameter_names(p::Running)
-
-Return the running parameter name as a one-element tuple of symbols.
-"""
-parameter_names(c::Running) = (Symbol(c.name),)
-
-"""
-    running_names(p::Running)
-
-Return the running parameter name as a one-element tuple of symbols. Plain
-`Running` parameters are always running.
-"""
-running_names(c::Running) = parameter_names(c)
-
-"""
-    fixed_names(p::Running)
-
-Return an empty tuple because plain `Running` parameters are always running.
-"""
-fixed_names(c::Running) = ()
-
-"""
-    parameter_uncertainties(p::Running)
-
-Return `missing` uncertainty metadata for a plain `Running` parameter.
-"""
-parameter_uncertainties(p::Running) = NamedTuple{(Symbol(p.name),)}((missing,))
-
-"""
-    parameter_upper_boundaries(p::Running)
-
-Return `Inf` as the default upper boundary for a plain `Running` parameter.
-"""
-parameter_upper_boundaries(c::Running) = NamedTuple{(Symbol(c.name),)}((Inf,))
-
-"""
-    parameter_lower_boundaries(p::Running)
-
-Return `-Inf` as the default lower boundary for a plain `Running` parameter.
-"""
-parameter_lower_boundaries(c::Running) = NamedTuple{(Symbol(c.name),)}((-Inf,))
-
-
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # mutable parameter, can be fixed and released
 """
@@ -172,57 +120,6 @@ Return metadata for a flexible parameter, including its fixed/free state.
 """
 parameter_metadata(c::FlexibleParameter) =
     _parameter_metadata_entry(c; name = c.name, value = c.value, fixed = c.fixed)
-
-"""
-    parameter_values(p::FlexibleParameter)
-
-Return the stored value for this parameter, whether it is currently fixed or free.
-"""
-parameter_values(c::FlexibleParameter) = NamedTuple{(Symbol(c.name),)}((c.value,))
-
-"""
-    parameter_names(p::FlexibleParameter)
-
-Return this parameter name as a one-element tuple of symbols.
-"""
-parameter_names(c::FlexibleParameter) = (Symbol(c.name),)
-
-"""
-    running_names(p::FlexibleParameter)
-
-Return this parameter name only when this parameter is currently free.
-"""
-running_names(c::FlexibleParameter) = c.fixed ? () : parameter_names(c)
-
-"""
-    fixed_names(p::FlexibleParameter)
-
-Return this parameter name only when this parameter is currently fixed.
-"""
-fixed_names(c::FlexibleParameter) = c.fixed ? parameter_names(c) : ()
-
-"""
-    parameter_uncertainties(p::FlexibleParameter)
-
-Return `missing` uncertainty metadata for a flexible parameter.
-"""
-parameter_uncertainties(p::FlexibleParameter) = NamedTuple{(Symbol(p.name),)}((missing,))
-
-"""
-    parameter_upper_boundaries(p::FlexibleParameter)
-
-Return `Inf` as the default upper boundary for a flexible parameter.
-"""
-parameter_upper_boundaries(p::FlexibleParameter) = NamedTuple{(Symbol(p.name),)}((Inf,))
-
-"""
-    parameter_lower_boundaries(p::FlexibleParameter)
-
-Return `-Inf` as the default lower boundary for a flexible parameter.
-"""
-parameter_lower_boundaries(p::FlexibleParameter) = NamedTuple{(Symbol(p.name),)}((-Inf,))
-
-
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # advanced parameter, can be fixed and released, and has boundaries and uncertainty
@@ -304,54 +201,3 @@ parameter_metadata(c::AdvancedParameter) = _parameter_metadata_entry(
     fixed = c.fixed,
 )
 
-"""
-    parameter_values(p::AdvancedParameter)
-
-Return the stored value for this parameter.
-"""
-parameter_values(c::AdvancedParameter) = NamedTuple{(Symbol(c.name),)}((c.value,))
-
-"""
-    parameter_names(p::AdvancedParameter)
-
-Return this parameter name as a one-element tuple of symbols.
-"""
-parameter_names(c::AdvancedParameter) = (Symbol(c.name),)
-
-"""
-    running_names(p::AdvancedParameter)
-
-Return this parameter name only when this parameter is currently free.
-"""
-running_names(c::AdvancedParameter) = c.fixed ? () : parameter_names(c)
-
-"""
-    fixed_names(p::AdvancedParameter)
-
-Return this parameter name only when this parameter is currently fixed.
-"""
-fixed_names(c::AdvancedParameter) = c.fixed ? parameter_names(c) : ()
-
-"""
-    parameter_uncertainties(p::AdvancedParameter)
-
-Return the stored uncertainty for this parameter.
-"""
-parameter_uncertainties(p::AdvancedParameter) =
-    NamedTuple{(Symbol(p.name),)}((p.uncertainty,))
-
-"""
-    parameter_upper_boundaries(p::AdvancedParameter)
-
-Return the upper boundary stored in `p.boundaries[2]`.
-"""
-parameter_upper_boundaries(p::AdvancedParameter) =
-    NamedTuple{(Symbol(p.name),)}((p.boundaries[2],))
-
-"""
-    parameter_lower_boundaries(p::AdvancedParameter)
-
-Return the lower boundary stored in `p.boundaries[1]`.
-"""
-parameter_lower_boundaries(p::AdvancedParameter) =
-    NamedTuple{(Symbol(p.name),)}((p.boundaries[1],))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,12 +12,13 @@ end)
     running = Running("x")
     @test BuildConstructors.value(fixed; pars = (x = 3.0,)) == 2.0
     @test BuildConstructors.value(running; pars = (x = 3.0,)) == 3.0
-    @test isequal(running_values(running), (x = missing,))
+    @test isequal(parameter_values(running), (x = missing,))
+    @test isequal(running_values(running), parameter_values(running))
 
     constructor = ConstructorOfAffineCore(Fixed(2.0), Running("b"))
     model = build_model(constructor, (b = 1.5,))
     @test model(3.0) == 7.5
-    @test isequal(running_values(constructor), (b = missing,))
+    @test isequal(parameter_values(constructor), (b = missing,))
 
     @test BuildConstructors._type_from_string("Fixed") === Fixed
     @test BuildConstructors._type_from_string("Int") === Int

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,8 @@ end)
     @test BuildConstructors.value(fixed; pars = (x = 3.0,)) == 2.0
     @test BuildConstructors.value(running; pars = (x = 3.0,)) == 3.0
     @test isequal(parameter_values(running), (x = missing,))
+    @test isequal(running_values(running), (x = missing,))
+    @test isequal(fixed_values(running), NamedTuple())
     @test running_names(running) == (:x,)
 
     constructor = ConstructorOfAffineCore(Fixed(2.0), Running("b"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,12 +13,13 @@ end)
     @test BuildConstructors.value(fixed; pars = (x = 3.0,)) == 2.0
     @test BuildConstructors.value(running; pars = (x = 3.0,)) == 3.0
     @test isequal(parameter_values(running), (x = missing,))
-    @test isequal(running_values(running), parameter_values(running))
+    @test running_names(running) == (:x,)
 
     constructor = ConstructorOfAffineCore(Fixed(2.0), Running("b"))
     model = build_model(constructor, (b = 1.5,))
     @test model(3.0) == 7.5
     @test isequal(parameter_values(constructor), (b = missing,))
+    @test parameter_names(constructor) == (:b,)
 
     @test BuildConstructors._type_from_string("Fixed") === Fixed
     @test BuildConstructors._type_from_string("Int") === Int

--- a/test/test-parameter.jl
+++ b/test/test-parameter.jl
@@ -90,6 +90,30 @@ end
     @test fixed_names(constructor) == (:c1,)
 end
 
+@testset "parameter_metadata" begin
+    release!(constructor)
+    metadata = parameter_metadata(constructor)
+
+    @test length(metadata) == 5
+    @test collect(getproperty.(metadata, :name)) == [:m, :Γ, :σ, :c1, :fs]
+    @test collect(getproperty.(metadata, :parameter_type)) == [
+        FlexibleParameter,
+        FlexibleParameter,
+        Running,
+        FlexibleParameter,
+        AdvancedParameter,
+    ]
+    @test parameter_names(metadata) == (:m, :Γ, :σ, :c1, :fs)
+    @test isequal(parameter_values(metadata), parameter_values(constructor))
+
+    fix!(constructor, (:m, :fs))
+    metadata = parameter_metadata(constructor)
+    @test running_names(metadata) == (:Γ, :σ, :c1)
+    @test fixed_names(metadata) == (:m, :fs)
+    @test isequal(running_values(metadata), running_values(constructor))
+    @test isequal(fixed_values(metadata), fixed_values(constructor))
+end
+
 @testset "running and fixed metadata filters" begin
     release!(constructor)
     fix!(constructor, (:m, :c1, :fs))
@@ -105,6 +129,28 @@ end
 
     @test running_lower_boundaries(constructor) == (Γ = -Inf, σ = -Inf)
     @test fixed_lower_boundaries(constructor) == (m = -Inf, c1 = -Inf, fs = 0.0)
+end
+
+@testset "shared parameter names do not break filtered collectors" begin
+    shared = ConstructorOfBW(
+        FlexibleParameter("shared", 2.0),
+        FlexibleParameter("shared", 0.2),
+        (1.0, 2.5),
+    )
+
+    metadata = parameter_metadata(shared)
+    @test length(metadata) == 2
+    @test collect(getproperty.(metadata, :name)) == [:shared, :shared]
+    @test parameter_names(shared) == (:shared,)
+    @test running_names(shared) == (:shared,)
+    @test isequal(parameter_values(shared), (shared = 0.2,))
+    @test isequal(running_values(shared), (shared = 0.2,))
+
+    fix!(shared, (:shared,))
+    @test running_names(shared) == ()
+    @test fixed_names(shared) == (:shared,)
+    @test isequal(running_values(shared), NamedTuple())
+    @test isequal(fixed_values(shared), (shared = 0.2,))
 end
 
 @testset "Release all, and fix all" begin

--- a/test/test-parameter.jl
+++ b/test/test-parameter.jl
@@ -66,6 +66,29 @@ end
     update!(constructor.model_p, (m = 2.0, Γ = 0.2))
 end
 
+@testset "released_values" begin
+    release!(constructor)
+    @test isequal(released_values(Fixed(1.0)), NamedTuple())
+    @test isequal(released_values(Running("x")), (x = missing,))
+    @test isequal(fixed_values(Fixed(1.0)), NamedTuple())
+    @test isequal(fixed_values(Running("x")), NamedTuple())
+    @test isequal(released_values(constructor), (m = 2.0, Γ = 0.2, σ = missing, c1 = 0.3, fs = 0.5))
+    @test isequal(fixed_values(constructor), NamedTuple())
+
+    fix!(constructor, (:m, :c1, :fs))
+    @test isequal(running_values(constructor), (m = 2.0, Γ = 0.2, σ = missing, c1 = 0.3, fs = 0.5))
+    @test isequal(released_values(constructor), (Γ = 0.2, σ = missing))
+    @test isequal(fixed_values(constructor), (m = 2.0, c1 = 0.3, fs = 0.5))
+    @test isequal(
+        merge(fixed_values(constructor), released_values(constructor)),
+        (m = 2.0, c1 = 0.3, fs = 0.5, Γ = 0.2, σ = missing),
+    )
+
+    release!(constructor, (:m, :fs))
+    @test isequal(released_values(constructor), (m = 2.0, Γ = 0.2, σ = missing, fs = 0.5))
+    @test isequal(fixed_values(constructor), (c1 = 0.3,))
+end
+
 @testset "Release all, and fix all" begin
     release!(constructor)
     @test constructor.model_p.description_of_m.fixed == false

--- a/test/test-parameter.jl
+++ b/test/test-parameter.jl
@@ -52,17 +52,17 @@ end
 
 
 @testset "Update and pickup" begin
-    @test running_values(constructor.model_p) == (m = 2.0, Γ = 0.2)
+    @test parameter_values(constructor.model_p) == (m = 2.0, Γ = 0.2)
     update!(constructor.model_p, (m = 1.9, Γ = 0.1))
-    @test running_values(constructor.model_p) == (m = 1.9, Γ = 0.1)
-    @test running_values(constructor) |> keys == (:m, :Γ, :σ, :c1, :fs)
+    @test parameter_values(constructor.model_p) == (m = 1.9, Γ = 0.1)
+    @test parameter_values(constructor) |> keys == (:m, :Γ, :σ, :c1, :fs)
     update!(constructor.model_p, (m = 2.0, Γ = 0.2))
 end
 
 @testset "Update works with ComponentArray" begin
-    @test running_values(constructor.model_p) == (m = 2.0, Γ = 0.2)
+    @test parameter_values(constructor.model_p) == (m = 2.0, Γ = 0.2)
     update!(constructor.model_p, ComponentArray(m = 1.9, Γ = 0.1))
-    @test running_values(constructor.model_p) == (m = 1.9, Γ = 0.1)
+    @test parameter_values(constructor.model_p) == (m = 1.9, Γ = 0.1)
     update!(constructor.model_p, (m = 2.0, Γ = 0.2))
 end
 
@@ -76,7 +76,8 @@ end
     @test isequal(fixed_values(constructor), NamedTuple())
 
     fix!(constructor, (:m, :c1, :fs))
-    @test isequal(running_values(constructor), (m = 2.0, Γ = 0.2, σ = missing, c1 = 0.3, fs = 0.5))
+    @test isequal(parameter_values(constructor), (m = 2.0, Γ = 0.2, σ = missing, c1 = 0.3, fs = 0.5))
+    @test isequal(running_values(constructor), parameter_values(constructor))
     @test isequal(released_values(constructor), (Γ = 0.2, σ = missing))
     @test isequal(fixed_values(constructor), (m = 2.0, c1 = 0.3, fs = 0.5))
     @test isequal(
@@ -102,41 +103,42 @@ end
     @test constructor.description_of_fs.fixed == true
 end
 
-@testset "running_uncertainties" begin
+@testset "parameter_uncertainties" begin
     # Test on Running
     r = Running("σ")
-    @test running_uncertainties(r) === (σ = missing,)
+    @test parameter_uncertainties(r) === (σ = missing,)
 
     # Test on Fixed
     f = Fixed(0.5)
-    @test running_uncertainties(f) == NamedTuple()
+    @test parameter_uncertainties(f) == NamedTuple()
 
     # Test on constructor - should collect from all fields
     # The constructor has: FlexibleParameter("m"), FlexibleParameter("Γ"), Fixed(0.0), Running("σ"), FlexibleParameter("c1"), FlexibleParameter("fs")
     # Only Running("σ") should contribute
-    @test running_uncertainties(constructor) ===
+    @test parameter_uncertainties(constructor) ===
           (m = missing, Γ = missing, σ = missing, c1 = missing, fs = 0.01)
-    @test keys(running_uncertainties(constructor)) == keys(running_values(constructor))
+    @test keys(parameter_uncertainties(constructor)) == keys(parameter_values(constructor))
+    @test isequal(running_uncertainties(constructor), parameter_uncertainties(constructor))
 end
 
-@testset "running_upper_boundaries" begin
+@testset "parameter_upper_boundaries" begin
     # Test on individual FlexibleParameter
     p = FlexibleParameter("test", 1.0)
-    @test running_upper_boundaries(p) == (test = Inf,)
+    @test parameter_upper_boundaries(p) == (test = Inf,)
 
     # Test on Running
     r = Running("σ")
-    @test running_upper_boundaries(r) == (σ = Inf,)
+    @test parameter_upper_boundaries(r) == (σ = Inf,)
 
     # Test on Fixed
     f = Fixed(0.5)
-    @test running_upper_boundaries(f) == NamedTuple()
+    @test parameter_upper_boundaries(f) == NamedTuple()
 
     # Test on constructor - should collect from all fields
     # The constructor has: FlexibleParameter("m"), FlexibleParameter("Γ"), Fixed(0.0), Running("σ"), FlexibleParameter("c1"), FlexibleParameter("fs")
     # All FlexibleParameters and Running should contribute with Inf
-    upper_bounds = running_upper_boundaries(constructor)
-    @test keys(upper_bounds) == keys(running_values(constructor))
+    upper_bounds = parameter_upper_boundaries(constructor)
+    @test keys(upper_bounds) == keys(parameter_values(constructor))
     @test upper_bounds.m == Inf
     @test upper_bounds.Γ == Inf
     @test upper_bounds.σ == Inf
@@ -145,27 +147,28 @@ end
     @test keys(upper_bounds) == (:m, :Γ, :σ, :c1, :fs)
 
     p_default = AdvancedParameter("advanced", 1.0)
-    @test running_upper_boundaries(p_default) == (advanced = Inf,)
+    @test parameter_upper_boundaries(p_default) == (advanced = Inf,)
+    @test isequal(running_upper_boundaries(constructor), parameter_upper_boundaries(constructor))
 end
 
-@testset "running_lower_boundaries" begin
+@testset "parameter_lower_boundaries" begin
     # Test on individual FlexibleParameter
     p = FlexibleParameter("test", 1.0)
-    @test running_lower_boundaries(p) == (test = -Inf,)
+    @test parameter_lower_boundaries(p) == (test = -Inf,)
 
     # Test on Running
     r = Running("σ")
-    @test running_lower_boundaries(r) == (σ = -Inf,)
+    @test parameter_lower_boundaries(r) == (σ = -Inf,)
 
     # Test on Fixed
     f = Fixed(0.5)
-    @test running_lower_boundaries(f) == NamedTuple()
+    @test parameter_lower_boundaries(f) == NamedTuple()
 
     # Test on constructor - should collect from all fields
     # The constructor has: FlexibleParameter("m"), FlexibleParameter("Γ"), Fixed(0.0), Running("σ"), FlexibleParameter("c1"), FlexibleParameter("fs")
     # All FlexibleParameters and Running should contribute with -Inf
-    lower_bounds = running_lower_boundaries(constructor)
-    @test keys(lower_bounds) == keys(running_values(constructor))
+    lower_bounds = parameter_lower_boundaries(constructor)
+    @test keys(lower_bounds) == keys(parameter_values(constructor))
     @test lower_bounds.m == -Inf
     @test lower_bounds.Γ == -Inf
     @test lower_bounds.σ == -Inf
@@ -174,5 +177,6 @@ end
     @test keys(lower_bounds) == (:m, :Γ, :σ, :c1, :fs)
 
     p_default = AdvancedParameter("advanced", 1.0)
-    @test running_lower_boundaries(p_default) == (advanced = -Inf,)
+    @test parameter_lower_boundaries(p_default) == (advanced = -Inf,)
+    @test isequal(running_lower_boundaries(constructor), parameter_lower_boundaries(constructor))
 end

--- a/test/test-parameter.jl
+++ b/test/test-parameter.jl
@@ -105,6 +105,7 @@ end
     ]
     @test parameter_names(metadata) == (:m, :Γ, :σ, :c1, :fs)
     @test isequal(parameter_values(metadata), parameter_values(constructor))
+    @test !any(==(Any), fieldtypes(typeof(parameter_values(metadata))))
 
     fix!(constructor, (:m, :fs))
     metadata = parameter_metadata(constructor)
@@ -145,6 +146,7 @@ end
     @test running_names(shared) == (:shared,)
     @test isequal(parameter_values(shared), (shared = 0.2,))
     @test isequal(running_values(shared), (shared = 0.2,))
+    @test fieldtypes(typeof(parameter_values(shared))) == (Float64,)
 
     fix!(shared, (:shared,))
     @test running_names(shared) == ()

--- a/test/test-parameter.jl
+++ b/test/test-parameter.jl
@@ -66,28 +66,28 @@ end
     update!(constructor.model_p, (m = 2.0, Γ = 0.2))
 end
 
-@testset "released_values" begin
+@testset "parameter, running, and fixed names" begin
     release!(constructor)
-    @test isequal(released_values(Fixed(1.0)), NamedTuple())
-    @test isequal(released_values(Running("x")), (x = missing,))
-    @test isequal(fixed_values(Fixed(1.0)), NamedTuple())
-    @test isequal(fixed_values(Running("x")), NamedTuple())
-    @test isequal(released_values(constructor), (m = 2.0, Γ = 0.2, σ = missing, c1 = 0.3, fs = 0.5))
-    @test isequal(fixed_values(constructor), NamedTuple())
+    @test parameter_names(Fixed(1.0)) == ()
+    @test running_names(Fixed(1.0)) == ()
+    @test fixed_names(Fixed(1.0)) == ()
+    @test parameter_names(Running("x")) == (:x,)
+    @test running_names(Running("x")) == (:x,)
+    @test fixed_names(Running("x")) == ()
+    @test parameter_names(constructor) == (:m, :Γ, :σ, :c1, :fs)
+    @test running_names(constructor) == (:m, :Γ, :σ, :c1, :fs)
+    @test fixed_names(constructor) == ()
 
     fix!(constructor, (:m, :c1, :fs))
     @test isequal(parameter_values(constructor), (m = 2.0, Γ = 0.2, σ = missing, c1 = 0.3, fs = 0.5))
-    @test isequal(running_values(constructor), parameter_values(constructor))
-    @test isequal(released_values(constructor), (Γ = 0.2, σ = missing))
-    @test isequal(fixed_values(constructor), (m = 2.0, c1 = 0.3, fs = 0.5))
-    @test isequal(
-        merge(fixed_values(constructor), released_values(constructor)),
-        (m = 2.0, c1 = 0.3, fs = 0.5, Γ = 0.2, σ = missing),
-    )
+    @test running_names(constructor) == (:Γ, :σ)
+    @test fixed_names(constructor) == (:m, :c1, :fs)
+    @test isequal(NamedTuple{running_names(constructor)}(parameter_values(constructor)), (Γ = 0.2, σ = missing))
+    @test isequal(NamedTuple{fixed_names(constructor)}(parameter_values(constructor)), (m = 2.0, c1 = 0.3, fs = 0.5))
 
     release!(constructor, (:m, :fs))
-    @test isequal(released_values(constructor), (m = 2.0, Γ = 0.2, σ = missing, fs = 0.5))
-    @test isequal(fixed_values(constructor), (c1 = 0.3,))
+    @test running_names(constructor) == (:m, :Γ, :σ, :fs)
+    @test fixed_names(constructor) == (:c1,)
 end
 
 @testset "Release all, and fix all" begin
@@ -117,8 +117,7 @@ end
     # Only Running("σ") should contribute
     @test parameter_uncertainties(constructor) ===
           (m = missing, Γ = missing, σ = missing, c1 = missing, fs = 0.01)
-    @test keys(parameter_uncertainties(constructor)) == keys(parameter_values(constructor))
-    @test isequal(running_uncertainties(constructor), parameter_uncertainties(constructor))
+    @test keys(parameter_uncertainties(constructor)) == parameter_names(constructor)
 end
 
 @testset "parameter_upper_boundaries" begin
@@ -148,7 +147,6 @@ end
 
     p_default = AdvancedParameter("advanced", 1.0)
     @test parameter_upper_boundaries(p_default) == (advanced = Inf,)
-    @test isequal(running_upper_boundaries(constructor), parameter_upper_boundaries(constructor))
 end
 
 @testset "parameter_lower_boundaries" begin
@@ -178,5 +176,4 @@ end
 
     p_default = AdvancedParameter("advanced", 1.0)
     @test parameter_lower_boundaries(p_default) == (advanced = -Inf,)
-    @test isequal(running_lower_boundaries(constructor), parameter_lower_boundaries(constructor))
 end

--- a/test/test-parameter.jl
+++ b/test/test-parameter.jl
@@ -90,6 +90,23 @@ end
     @test fixed_names(constructor) == (:c1,)
 end
 
+@testset "running and fixed metadata filters" begin
+    release!(constructor)
+    fix!(constructor, (:m, :c1, :fs))
+
+    @test isequal(running_values(constructor), (Γ = 0.2, σ = missing))
+    @test isequal(fixed_values(constructor), (m = 2.0, c1 = 0.3, fs = 0.5))
+
+    @test isequal(running_uncertainties(constructor), (Γ = missing, σ = missing))
+    @test isequal(fixed_uncertainties(constructor), (m = missing, c1 = missing, fs = 0.01))
+
+    @test running_upper_boundaries(constructor) == (Γ = Inf, σ = Inf)
+    @test fixed_upper_boundaries(constructor) == (m = Inf, c1 = Inf, fs = 1.0)
+
+    @test running_lower_boundaries(constructor) == (Γ = -Inf, σ = -Inf)
+    @test fixed_lower_boundaries(constructor) == (m = -Inf, c1 = -Inf, fs = 0.0)
+end
+
 @testset "Release all, and fix all" begin
     release!(constructor)
     @test constructor.model_p.description_of_m.fixed == false


### PR DESCRIPTION
## Summary
- Add exported parameter_metadata as the canonical raw parameter collection; entries preserve duplicate/shared names and include value, uncertainty, bounds, fixed state, descriptor, and descriptor type.
- Derive parameter_*, running_*, and fixed_* value/bounds/uncertainty collectors from the metadata projection layer.
- Add parameter_names, running_names, and fixed_names as deduplicated tuple-of-symbol state/name collectors after fix! / release!.
- Bump package version to 0.6.0 and add a changelog entry for the new collector API.

## Test plan
- julia --project=. -e 'using Pkg; Pkg.test()'
- julia --project=. -e 'using BuildConstructors; @assert parameter_names(Running("x")) == (:x,)'
- julia --project=. -e 'using Pkg; Pkg.status("BuildConstructors")'