### PR TITLE
Add 2D Minuit2 fitting tutorial

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,8 +17,10 @@ PhysicsModelsExt = ["Distributions", "DistributionsHEP", "JSON", "NumericalDistr
 
 [sources]
 DistributionsHEP = {url = "https://github.com/JuliaHEP/DistributionsHEP.jl", rev = "codex/extended-mixture-model"}
+Minuit2 = {url = "https://github.com/JuliaHEP/Minuit2.jl", rev = "codex/remove-roofit-core"}
 
 [compat]
+Minuit2 = ">=0.3"
 ComponentArrays = ">=0.15"
 Distributions = ">=0.25"
 DistributionsHEP = "0.6"
@@ -33,6 +35,7 @@ ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 DistributionsHEP = "0d0d6f60-fb7b-48ca-90bb-e14e8b1655a7"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+Minuit2 = "37821647-3276-4ed8-9a4e-bc9886b3c106"
 NumericalDistributions = "13416b18-ec19-40e4-a123-e345ab61da74"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
@@ -43,5 +46,6 @@ test = [
     "Distributions",
     "DistributionsHEP",
     "JSON",
+    "Minuit2",
     "NumericalDistributions",
 ]

--- a/docs/generate_literate.jl
+++ b/docs/generate_literate.jl
@@ -1,9 +1,16 @@
 using Literate
 
-Literate.markdown(
-    joinpath(@__DIR__, "literate", "tutorials", "2d-model-construction.jl"),
-    joinpath(@__DIR__, "src", "tutorials");
-    documenter=false,
-    execute=false,
-    credit=false,
-)
+const LITERATE_TUTORIALS = [
+    "2d-model-construction.jl",
+    "2d-minuit2-fit.jl",
+]
+
+for tutorial in LITERATE_TUTORIALS
+    Literate.markdown(
+        joinpath(@__DIR__, "literate", "tutorials", tutorial),
+        joinpath(@__DIR__, "src", "tutorials");
+        documenter=false,
+        execute=false,
+        credit=false,
+    )
+end

--- a/docs/literate/tutorials/2d-minuit2-fit.jl
+++ b/docs/literate/tutorials/2d-minuit2-fit.jl
@@ -1,0 +1,152 @@
+# # 2D Minuit2 Fit
+#
+# This tutorial continues the 2D model construction example and fits the
+# extended 2D model with `Minuit2.jl`. It keeps the same explicit workflow:
+# include the model definitions, load the data in the script, build the
+# constructor in visible blocks, and only then set up the minimizer.
+#
+# The low-level Minuit2 call goes through a small local adapter,
+# `src/Minuit2CAInterface.jl`. That wrapper is kept separate because the generic
+# `Optimization.jl` interface still does not expose per-parameter Minuit errors,
+# fixed masks, or post-fit diagnostics such as `hesse!`.
+
+using Arrow
+using BuildConstructors
+using ComponentArrays
+using DataFrames
+using Distributions
+using DistributionsHEP
+
+example_dir = joinpath(@__DIR__, "..", "..", "..", "examples", "2d_distribution_fit")
+model_source = joinpath(example_dir, "src", "two_dimensional_model.jl")
+interface_source = joinpath(example_dir, "src", "Minuit2CAInterface.jl")
+
+include(model_source)
+include(interface_source)
+
+using .Minuit2CAInterface
+
+# ## Load the data
+#
+# The data loading matches the model-construction tutorial: convert MeV to GeV,
+# apply the fit-window cuts, and keep the event list in the script.
+
+fit_events_path = joinpath(example_dir, "data", "fit_events.arrow")
+fit_df = DataFrame(Arrow.Table(fit_events_path); copycols = true)
+
+transform!(
+    fit_df,
+    :mKK1 => ByRow(x -> x / 1e3) => :mKK1,
+    :mKK2 => ByRow(x -> x / 1e3) => :mKK2,
+)
+
+subset!(
+    fit_df,
+    :mKK1 => x -> KK_LIMITS[1] .< x .< KK_LIMITS[2],
+    :mKK2 => x -> KK_LIMITS[1] .< x .< KK_LIMITS[2],
+)
+
+data2d = collect.(zip(fit_df.mKK1, fit_df.mKK2))
+n_events = length(data2d)
+
+# ## Build the one-dimensional components
+
+signal_kk = ConstructorOfFit2DTruncatedCrystalBall(
+    AdvancedParameter("mu_B", 1.002 * PHI_MASS_GEV; boundaries = KK_LIMITS, uncertainty = 1e-4),
+    AdvancedParameter("sigma_B", 0.0025; boundaries = (1e-4, 0.02), uncertainty = 2e-4),
+    AdvancedParameter("alpha_B", 2.0; boundaries = (0.2, 10.0), uncertainty = 0.1),
+    BuildConstructors.Fixed(2.5),
+    KK_LIMITS,
+)
+
+background_kk = ConstructorOfFit2DTruncatedExponential(
+    AdvancedParameter("k_bkg_kk", -0.2; boundaries = (-50.0, -1e-6), uncertainty = 0.05),
+    KK_LIMITS,
+)
+
+# ## Assemble the extended 2D model
+
+full_model_constructor = ConstructorOfFit2DExtendedKKComponents(
+    signal_kk,
+    background_kk,
+    AdvancedParameter("y_phiphi", 0.3 * n_events; boundaries = (0.0, n_events), uncertainty = sqrt(n_events)),
+    AdvancedParameter("y_mixed", 0.1 * n_events; boundaries = (0.0, n_events), uncertainty = sqrt(n_events)),
+    AdvancedParameter("y_kkkk", 0.6 * n_events; boundaries = (0.0, n_events), uncertainty = sqrt(n_events)),
+)
+
+# ## Release the yield parameters
+#
+# Start from a fully fixed constructor, then release the three extended yields.
+# `running_names` reports the active subset that Minuit will see.
+
+fix!(full_model_constructor)
+release!(full_model_constructor, (:y_phiphi, :y_mixed, :y_kkkk))
+released = running_names(full_model_constructor)
+
+# ## Project the released subset to `ComponentArray`s
+#
+# Minuit receives only the released parameters. The descriptor tree still stores
+# the fixed shape parameters; `build_model` reads them from the constructor when
+# the objective passes a released-only `ComponentArray`.
+
+all_start = ComponentArray(parameter_values(full_model_constructor))
+all_lower = ComponentArray(parameter_lower_boundaries(full_model_constructor))
+all_upper = ComponentArray(parameter_upper_boundaries(full_model_constructor))
+all_steps = ComponentArray(
+    map(v -> coalesce(v, 0.1), parameter_uncertainties(full_model_constructor)),
+)
+
+start = all_start[released]
+lower = all_lower[released]
+upper = all_upper[released]
+steps = all_steps[released]
+
+# ## Define the negative log-likelihood objective
+#
+# Subtract the starting NLL so Minuit works with a small offset around zero.
+# The fitted minimum is therefore a ΔNLL relative to the starting point.
+
+base_nll = extended_negative_log_likelihood(full_model_constructor, start, data2d)
+objective(pars) = extended_negative_log_likelihood(full_model_constructor, pars, data2d) - base_nll
+
+# ## Run Minuit2 through the local adapter
+#
+# - `lower` / `upper` keep yields inside the physical region.
+# - `errors = steps` passes descriptor uncertainties as Minuit step sizes.
+# - `errordef = 0.5` is appropriate for a negative log-likelihood.
+# - `strategy = 1` is the default balance between robustness and call count.
+
+result = optimize(
+    objective,
+    start,
+    Minuit2CA(;
+        strategy = 1,
+        tolerance = 0.01,
+        errordef = 0.5,
+        maxcalls = 500,
+        errors = steps,
+        lower,
+        upper,
+        names = released,
+    ),
+)
+
+fitted = minimizer(result)
+minuit = original(result)
+
+fitted
+minimum(result)
+converged(result)
+minuit.edm
+minuit.nfcn
+
+# ## Write the fit back into the constructor
+#
+# `update!` stores the fitted values in the descriptor tree. The underlying
+# Minuit object remains available for follow-up calls such as `hesse!`.
+
+BuildConstructors.update!(full_model_constructor, fitted)
+parameter_values(full_model_constructor)
+
+hesse!(result; strategy = 1, maxcalls = 100)
+minuit.errors

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -44,6 +44,7 @@ bc_docs_doctest_only && doctest(BuildConstructors)
                 "Optim with ComponentArrays" => "tutorials/optim-componentarrays.md",
                 "Minuit2 with ComponentArrays" => "tutorials/minuit2-componentarrays.md",
                 "2D Model Construction" => "tutorials/2d-model-construction.md",
+                "2D Minuit2 Fit" => "tutorials/2d-minuit2-fit.md",
             ],
         ],
         checkdocs=:exports,

--- a/examples/2d_distribution_fit/src/Minuit2CAInterface.jl
+++ b/examples/2d_distribution_fit/src/Minuit2CAInterface.jl
@@ -1,0 +1,149 @@
+# Local Minuit2 + ComponentArray adapter for the 2D fit tutorials.
+#
+# This file is intentionally kept separate from `two_dimensional_model.jl` because
+# the generic ecosystem still lacks a Minuit2/Optimization.jl surface that exposes
+# per-parameter errors, fixed masks, and post-fit diagnostics such as `hesse!`.
+# Expect this adapter to move upstream once those pieces exist.
+module Minuit2CAInterface
+
+using ComponentArrays
+using ComponentArrays: getaxes
+using Minuit2
+
+import Base: minimum
+
+export Minuit2CA
+export Minuit2CAResult
+export optimize
+export minimizer
+export minimum
+export converged
+export original
+export hesse!
+
+Base.@kwdef struct Minuit2CA
+    strategy::Int = 1
+    tolerance::Float64 = 0.1
+    errordef::Float64 = 1.0
+    maxcalls::Int = 0
+    errors::Any = nothing
+    lower::Any = nothing
+    upper::Any = nothing
+    limits::Any = nothing
+    fixed::Any = nothing
+    names::Any = nothing
+    grad::Any = nothing
+    precision::Any = nothing
+    run_hesse::Bool = false
+    hesse_strategy::Int = strategy
+    hesse_maxcalls::Int = 0
+    migrad_iterate::Int = 5
+    migrad_use_simplex::Bool = true
+end
+
+struct Minuit2CAResult{T, M}
+    minimizer::T
+    minimum::Float64
+    original::M
+    converged::Bool
+    iterations::Int
+    objective_calls::Int
+    edm::Float64
+    valid::Bool
+    reached_call_limit::Bool
+    above_max_edm::Bool
+end
+
+minimizer(result::Minuit2CAResult) = result.minimizer
+minimum(result::Minuit2CAResult) = result.minimum
+converged(result::Minuit2CAResult) = result.converged
+original(result::Minuit2CAResult) = result.original
+
+function hesse!(result::Minuit2CAResult; strategy::Int = 1, maxcalls::Int = 0)
+    Minuit2.hesse!(original(result); strategy, maxcalls)
+    return result
+end
+
+function Base.show(io::IO, result::Minuit2CAResult)
+    print(
+        io,
+        "Minuit2CAResult(minimum = $(result.minimum), converged = $(result.converged), ",
+        "calls = $(result.objective_calls), edm = $(result.edm))",
+    )
+end
+
+function optimize(objective, initial::ComponentArray, settings::Minuit2CA = Minuit2CA())
+    minuit = Minuit(objective, initial; _minuit_keywords(initial, settings)...)
+    migrad!(
+        minuit,
+        settings.strategy;
+        ncall = settings.maxcalls,
+        iterate = settings.migrad_iterate,
+        use_simplex = settings.migrad_use_simplex,
+    )
+    if settings.run_hesse
+        hesse!(minuit; strategy = settings.hesse_strategy, maxcalls = settings.hesse_maxcalls)
+    end
+    values = ComponentArray(collect(minuit.values), getaxes(minuit.values))
+    return Minuit2CAResult(
+        values,
+        minuit.fval,
+        minuit,
+        minuit.is_valid && !minuit.has_reached_call_limit && !minuit.is_above_max_edm,
+        Int(minuit.niter),
+        Int(minuit.nfcn),
+        minuit.edm,
+        minuit.is_valid,
+        minuit.has_reached_call_limit,
+        minuit.is_above_max_edm,
+    )
+end
+
+function _minuit_keywords(initial, settings::Minuit2CA)
+    kwargs = Dict{Symbol, Any}(
+        :arraycall => true,
+        :errordef => settings.errordef,
+        :tolerance => settings.tolerance,
+        :strategy => settings.strategy,
+    )
+
+    names = isnothing(settings.names) ? _default_names(initial) : collect(settings.names)
+    kwargs[:names] = string.(names)
+
+    !isnothing(settings.errors) && (kwargs[:error] = collect(settings.errors))
+    !isnothing(settings.fixed) && (kwargs[:fixed] = collect(settings.fixed))
+    !isnothing(settings.grad) && (kwargs[:grad] = settings.grad)
+    !isnothing(settings.precision) && (kwargs[:precision] = settings.precision)
+
+    limits = _limits(settings, length(initial))
+    !isnothing(limits) && (kwargs[:limits] = limits)
+
+    _check_length(kwargs[:names], length(initial), "names")
+    haskey(kwargs, :error) && _check_length(kwargs[:error], length(initial), "errors")
+    haskey(kwargs, :fixed) && _check_length(kwargs[:fixed], length(initial), "fixed")
+    haskey(kwargs, :limits) && _check_length(kwargs[:limits], length(initial), "limits")
+    return kwargs
+end
+
+function _default_names(initial::ComponentArray)
+    names = collect(keys(initial))
+    length(names) == length(initial) && return names
+    return [Symbol(:p, i) for i in 1:length(initial)]
+end
+
+function _limits(settings::Minuit2CA, npars)
+    if !isnothing(settings.limits)
+        return collect(settings.limits)
+    end
+    isnothing(settings.lower) && isnothing(settings.upper) && return nothing
+    lower = isnothing(settings.lower) ? fill(-Inf, npars) : collect(settings.lower)
+    upper = isnothing(settings.upper) ? fill(Inf, npars) : collect(settings.upper)
+    return collect(zip(lower, upper))
+end
+
+function _check_length(values, expected, label)
+    length(values) == expected && return nothing
+    throw(ArgumentError("Minuit2CA $(label) length $(length(values)) does not match parameter length $(expected)"))
+end
+
+end

--- a/examples/2d_distribution_fit/src/Minuit2CAInterface.jl
+++ b/examples/2d_distribution_fit/src/Minuit2CAInterface.jl
@@ -21,19 +21,23 @@ export converged
 export original
 export hesse!
 
+const OptionalRealVector = Union{Nothing, AbstractVector{<:Real}}
+const OptionalLimitVector = Union{Nothing, AbstractVector{<:Tuple{<:Real, <:Real}}}
+const OptionalNameCollection = Union{Nothing, AbstractVector{Symbol}, Tuple{Vararg{Symbol}}}
+
 Base.@kwdef struct Minuit2CA
     strategy::Int = 1
     tolerance::Float64 = 0.1
     errordef::Float64 = 1.0
     maxcalls::Int = 0
-    errors::Any = nothing
-    lower::Any = nothing
-    upper::Any = nothing
-    limits::Any = nothing
-    fixed::Any = nothing
-    names::Any = nothing
-    grad::Any = nothing
-    precision::Any = nothing
+    errors::OptionalRealVector = nothing
+    lower::OptionalRealVector = nothing
+    upper::OptionalRealVector = nothing
+    limits::OptionalLimitVector = nothing
+    fixed::Union{Nothing, AbstractVector{Bool}} = nothing
+    names::OptionalNameCollection = nothing
+    grad::Union{Nothing, Function} = nothing
+    precision::Union{Nothing, Real} = nothing
     run_hesse::Bool = false
     hesse_strategy::Int = strategy
     hesse_maxcalls::Int = 0
@@ -72,8 +76,17 @@ function Base.show(io::IO, result::Minuit2CAResult)
     )
 end
 
+function _wrap_objective(objective, axes)
+    return function wrapped_objective(p)
+        pars = p isa ComponentArray ? p : ComponentArray(p, axes)
+        return objective(pars)
+    end
+end
+
 function optimize(objective, initial::ComponentArray, settings::Minuit2CA = Minuit2CA())
-    minuit = Minuit(objective, initial; _minuit_keywords(initial, settings)...)
+    axes = getaxes(initial)
+    wrapped_objective = _wrap_objective(objective, axes)
+    minuit = Minuit(wrapped_objective, initial; _minuit_keywords(initial, settings)...)
     migrad!(
         minuit,
         settings.strategy;
@@ -84,7 +97,7 @@ function optimize(objective, initial::ComponentArray, settings::Minuit2CA = Minu
     if settings.run_hesse
         hesse!(minuit; strategy = settings.hesse_strategy, maxcalls = settings.hesse_maxcalls)
     end
-    values = ComponentArray(collect(minuit.values), getaxes(minuit.values))
+    values = ComponentArray(collect(minuit.values), axes)
     return Minuit2CAResult(
         values,
         minuit.fval,

--- a/test/examples/test_minuit2_ca_interface.jl
+++ b/test/examples/test_minuit2_ca_interface.jl
@@ -1,0 +1,33 @@
+using ComponentArrays
+
+include(joinpath(@__DIR__, "..", "..", "examples", "2d_distribution_fit", "src", "Minuit2CAInterface.jl"))
+
+using .Minuit2CAInterface: Minuit2CA, Minuit2CAInterface, converged, hesse!, minimizer, minimum, optimize, original
+
+@testset "Minuit2 ComponentArray interface" begin
+    initial = ComponentArray(a = 1.0, b = 2.0)
+    lower = ComponentArray(a = -10.0, b = -10.0)
+    upper = ComponentArray(a = 10.0, b = 10.0)
+    errors = ComponentArray(a = 0.25, b = 0.5)
+
+    result = optimize(
+        x -> sum(abs2, x),
+        initial,
+        Minuit2CA(;
+            errors,
+            lower,
+            upper,
+            maxcalls = 50,
+            tolerance = 0.01,
+        ),
+    )
+
+    @test minimizer(result) isa ComponentArray
+    @test keys(minimizer(result)) == (:a, :b)
+    @test minimum(result) < 1e-3
+    @test converged(result)
+    @test original(result).names == ["a", "b"]
+    @test original(result).limits == [(-10.0, 10.0), (-10.0, 10.0)]
+    @test hesse!(result; strategy = 1, maxcalls = 20) === result
+    @test original(result).errors isa ComponentArray
+end

--- a/test/examples/test_minuit2_ca_interface.jl
+++ b/test/examples/test_minuit2_ca_interface.jl
@@ -30,4 +30,18 @@ using .Minuit2CAInterface: Minuit2CA, Minuit2CAInterface, converged, hesse!, min
     @test original(result).limits == [(-10.0, 10.0), (-10.0, 10.0)]
     @test hesse!(result; strategy = 1, maxcalls = 20) === result
     @test original(result).errors isa ComponentArray
+
+    named_result = optimize(
+        pars -> pars.a^2 + pars.b^2,
+        initial,
+        Minuit2CA(;
+            errors,
+            lower,
+            upper,
+            maxcalls = 50,
+            tolerance = 0.01,
+        ),
+    )
+    @test keys(minimizer(named_result)) == (:a, :b)
+    @test minimum(named_result) < 1e-3
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -215,3 +215,7 @@ end
 @testset "Flexible Parameter" begin
     include("test-parameter.jl")
 end
+
+@testset "Minuit2 ComponentArray interface" begin
+    include("examples/test_minuit2_ca_interface.jl")
+end


### PR DESCRIPTION
## Summary
- Add the second consolidated 2D tutorial: explicit data loading, constructor blocks, released-parameter projection, and a yield-only Minuit2 fit on the extended model from PR #37.
- Introduce `Minuit2CAInterface.jl` as a labeled local adapter for per-parameter Minuit errors, bounds, and post-fit `hesse!` access.
- Wire the Literate source into docs generation and add a smoke test for the adapter.

## Test plan
- [x] `Pkg.test()` passes locally, including `test/examples/test_minuit2_ca_interface.jl`
- [x] `julia --project=docs docs/generate_literate.jl` generates `2d-minuit2-fit.md`
- [ ] CI docs build on this PR


Made with [Cursor](https://cursor.com)