### PR TITLE
Preserve declaration order in @with_parameters constructor arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project are documented in this file.
 
+## Unreleased
+
+### Changed
+
+- `@with_parameters`: generated struct fields and constructor positional arguments now follow macro header declaration order instead of reordering by field kind (parametric, descriptor, constant).
+
+### Breaking
+
+- `@with_parameters`: constructor positional argument order now matches the macro field list. Code that relied on the previous reordering (for example `ConstructorOfPRBModel(model_p, model_r, model_b, fs, ...)`) must pass arguments in declaration order (`ConstructorOfPRBModel(fs, model_p, model_r, model_b, ...)`). Fixes #39.
+
 ## 0.6.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project are documented in this file.
 
-## Unreleased
+## 0.7.0
 
 ### Changed
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BuildConstructors"
 uuid = "63b9b590-f22f-4e79-810f-ea9ba6849c26"
 authors = ["Robert Hentges <robert.hentges@cern.ch>"]
-version = "0.6.0"
+version = "0.7.0"
 
 [deps]
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"

--- a/README.md
+++ b/README.md
@@ -229,9 +229,8 @@ is a parameter descriptor, so the generated constructor is called as:
 c = ConstructorOfScaled(child_constructor, Running("scale"))
 ```
 
-The generated field order is stable: plain parametric fields first, parameter
-descriptor fields second, and typed constant fields last. That means a mixed
-declaration such as:
+The generated struct fields and constructor positional arguments follow the same
+order as the field list in the macro header. For example:
 
 ```julia
 @with_parameters(Windowed; model, μ::P, support::Tuple{Float64,Float64}, begin
@@ -246,7 +245,7 @@ ConstructorOfWindowed(model, μ_descriptor, support)
 ```
 
 Use the macro when that generated shape is clear and useful. Write the constructor
-and `build_model` by hand when you need a custom field order, extra validation,
+and `build_model` by hand when you need extra validation,
 special constructors, or a more explicit API.
 
 ## Serialization

--- a/ext/PhysicsModelsExt/physics_io.jl
+++ b/ext/PhysicsModelsExt/physics_io.jl
@@ -265,6 +265,6 @@ function BuildConstructors.deserialize(::Type{<:ConstructorOfPRBModel}, all_fiel
 
     support = all_fields["support"] |> Tuple
     grid_size = Int(all_fields["grid_size"])
-    ConstructorOfPRBModel(model_p, model_r, model_b, description_of_fs, support, grid_size),
+    ConstructorOfPRBModel(description_of_fs, model_p, model_r, model_b, support, grid_size),
     appendix
 end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -105,29 +105,21 @@ function add_struct_field!(struct_fields, field::ConstantField, _)
     return nothing  # unused index slot for ConstantField
 end
 
-# Helper: Generate struct fields in reordered format: parametric first, then parameters, then constants
+# Helper: Generate struct fields in macro header declaration order
 function generate_struct_fields(ordered_fields)
     struct_fields = Expr(:block)
 
-    # Track indices for type parameters
     param_idx = 1
     parametric_idx = 1
 
-    # Parametric fields (declaration order)
     for field in ordered_fields
-        field isa ParametricField &&
-            (parametric_idx = add_struct_field!(struct_fields, field, parametric_idx))
-    end
-
-    # Descriptor fields (`::P`)
-    for field in ordered_fields
-        field isa DescriptorField &&
-            (param_idx = add_struct_field!(struct_fields, field, param_idx))
-    end
-
-    # Typed constant fields
-    for field in ordered_fields
-        field isa ConstantField && add_struct_field!(struct_fields, field, nothing)
+        if field isa ParametricField
+            parametric_idx = add_struct_field!(struct_fields, field, parametric_idx)
+        elseif field isa DescriptorField
+            param_idx = add_struct_field!(struct_fields, field, param_idx)
+        elseif field isa ConstantField
+            add_struct_field!(struct_fields, field, nothing)
+        end
     end
 
     return struct_fields
@@ -312,9 +304,8 @@ The macro separates fields into three roles:
   inferred type parameter. This is useful for nested constructors or arbitrary
   user objects. Inside `body`, use bare `field`.
 
-The generated constructor argument order is parametric fields first, parameter
-descriptor fields second, and constant fields last. This keeps all generated
-constructors predictable even when fields are declared in a mixed order.
+The generated struct fields and constructor positional arguments follow the same
+order as the field list in the macro header.
 
 Inside `body`, every field name from the header is a local binding: parameter
 descriptors (`::P`) are resolved via `BuildConstructors.value`; parametric and

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -85,24 +85,24 @@ function generate_type_parameters(n_params, n_parametric_fields)
     return param_type_params, parametric_type_params
 end
 
-# Multiple dispatch: Add struct field definition based on field type
-# Mutates struct_fields
-function add_struct_field!(struct_fields, field::ParametricField, parametric_idx)
+# Multiple dispatch: Add struct field definition based on field type.
+# Takes both index counters; each method returns the updated pair.
+function add_struct_field!(struct_fields, field::ParametricField, param_idx, parametric_idx)
     type_param = Symbol("P", parametric_idx)
     push!(struct_fields.args, Expr(:(::), field.name, type_param))
-    return parametric_idx + 1
+    return param_idx, parametric_idx + 1
 end
 
-function add_struct_field!(struct_fields, field::DescriptorField, param_idx)
+function add_struct_field!(struct_fields, field::DescriptorField, param_idx, parametric_idx)
     type_param = Symbol("T", param_idx)
     field_name = Symbol("description_of_", field.name)
     push!(struct_fields.args, Expr(:(::), field_name, type_param))
-    return param_idx + 1
+    return param_idx + 1, parametric_idx
 end
 
-function add_struct_field!(struct_fields, field::ConstantField, _)
+function add_struct_field!(struct_fields, field::ConstantField, param_idx, parametric_idx)
     push!(struct_fields.args, Expr(:(::), field.name, field.type_expr))
-    return nothing  # unused index slot for ConstantField
+    return param_idx, parametric_idx
 end
 
 # Helper: Generate struct fields in macro header declaration order
@@ -113,13 +113,8 @@ function generate_struct_fields(ordered_fields)
     parametric_idx = 1
 
     for field in ordered_fields
-        if field isa ParametricField
-            parametric_idx = add_struct_field!(struct_fields, field, parametric_idx)
-        elseif field isa DescriptorField
-            param_idx = add_struct_field!(struct_fields, field, param_idx)
-        elseif field isa ConstantField
-            add_struct_field!(struct_fields, field, nothing)
-        end
+        param_idx, parametric_idx =
+            add_struct_field!(struct_fields, field, param_idx, parametric_idx)
     end
 
     return struct_fields

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,6 +78,7 @@ end
 
 
 cM_running_w = ConstructorOfPRBModel(
+    Fixed(0.5),
     ConstructorOfBW(Fixed(3.8), Fixed(0.1), (1.0, 2.6)),
     ConstructorOfCBpSECH(
         Fixed(0.002795),
@@ -91,7 +92,6 @@ cM_running_w = ConstructorOfPRBModel(
         (-0.5, 0.5),
     ),
     ConstructorOfPol1(Fixed(0.1), (1.0, 2.6)),
-    Fixed(0.5),
     (1.1, 2.5),
     10000,
 )

--- a/test/test-macro.jl
+++ b/test/test-macro.jl
@@ -137,8 +137,7 @@ end
 
 @testset "Macro constant slot: bare field name" begin
     inner = ConstructorOfGaussian(Fixed(0.0), Fixed(0.1), (-0.5, 0.5))
-    # Argument order: descriptor fields, then constant fields.
-    cs = ConstructorOfScaleMacroConstD(Fixed(2.0), inner)
+    cs = ConstructorOfScaleMacroConstD(inner, Fixed(2.0))
     model = build_model(cs, NamedTuple())
     @test model isa Distribution
     @test pdf(model, 0.0) > 0
@@ -166,10 +165,13 @@ end
 end)
 
 @testset "constant slot named c before descriptors" begin
-    # Constructor order is descriptors first (`λ`), then typed constants (`c`), regardless of
-    # declaration order in the macro header (see package docs).
-    ct = ConstructorOfFieldNamedCSlotConstFirst(Fixed(10.0), 2.0)
+    ct = ConstructorOfFieldNamedCSlotConstFirst(2.0, Fixed(10.0))
     @test build_model(ct, NamedTuple()) == 12.0
+end
+
+@testset "constructor argument order matches declaration order" begin
+    @test fieldnames(ConstructorOfFieldNamedCSlotConstFirst) == (:c, :description_of_λ)
+    @test fieldnames(ConstructorOfScaleMacroConstD) == (:D, :description_of_scale)
 end
 
 println("All macro tests passed!")

--- a/test/test-parameter.jl
+++ b/test/test-parameter.jl
@@ -3,10 +3,10 @@ using ComponentArrays
 using Test
 
 constructor = ConstructorOfPRBModel(
+    AdvancedParameter("fs", 0.5; boundaries = (0.0, 1.0), uncertainty = 0.01),
     ConstructorOfBW(FlexibleParameter("m", 2.0), FlexibleParameter("Γ", 0.2), (1.0, 2.5)),
     ConstructorOfGaussian(Fixed(0.0), Running("σ"), (-0.5, 0.5)),
     ConstructorOfPol1(FlexibleParameter("c1", 0.3), (1.0, 2.5)),
-    AdvancedParameter("fs", 0.5; boundaries = (0.0, 1.0), uncertainty = 0.01),
     (1.0, 2.5),
     10000,
 )
@@ -55,7 +55,7 @@ end
     @test parameter_values(constructor.model_p) == (m = 2.0, Γ = 0.2)
     update!(constructor.model_p, (m = 1.9, Γ = 0.1))
     @test parameter_values(constructor.model_p) == (m = 1.9, Γ = 0.1)
-    @test parameter_values(constructor) |> keys == (:m, :Γ, :σ, :c1, :fs)
+    @test parameter_values(constructor) |> keys == (:fs, :m, :Γ, :σ, :c1)
     update!(constructor.model_p, (m = 2.0, Γ = 0.2))
 end
 
@@ -74,19 +74,19 @@ end
     @test parameter_names(Running("x")) == (:x,)
     @test running_names(Running("x")) == (:x,)
     @test fixed_names(Running("x")) == ()
-    @test parameter_names(constructor) == (:m, :Γ, :σ, :c1, :fs)
-    @test running_names(constructor) == (:m, :Γ, :σ, :c1, :fs)
+    @test parameter_names(constructor) == (:fs, :m, :Γ, :σ, :c1)
+    @test running_names(constructor) == (:fs, :m, :Γ, :σ, :c1)
     @test fixed_names(constructor) == ()
 
     fix!(constructor, (:m, :c1, :fs))
-    @test isequal(parameter_values(constructor), (m = 2.0, Γ = 0.2, σ = missing, c1 = 0.3, fs = 0.5))
+    @test isequal(parameter_values(constructor), (fs = 0.5, m = 2.0, Γ = 0.2, σ = missing, c1 = 0.3))
     @test running_names(constructor) == (:Γ, :σ)
-    @test fixed_names(constructor) == (:m, :c1, :fs)
+    @test fixed_names(constructor) == (:fs, :m, :c1)
     @test isequal(NamedTuple{running_names(constructor)}(parameter_values(constructor)), (Γ = 0.2, σ = missing))
-    @test isequal(NamedTuple{fixed_names(constructor)}(parameter_values(constructor)), (m = 2.0, c1 = 0.3, fs = 0.5))
+    @test isequal(NamedTuple{fixed_names(constructor)}(parameter_values(constructor)), (fs = 0.5, m = 2.0, c1 = 0.3))
 
     release!(constructor, (:m, :fs))
-    @test running_names(constructor) == (:m, :Γ, :σ, :fs)
+    @test running_names(constructor) == (:fs, :m, :Γ, :σ)
     @test fixed_names(constructor) == (:c1,)
 end
 
@@ -95,22 +95,22 @@ end
     metadata = parameter_metadata(constructor)
 
     @test length(metadata) == 5
-    @test collect(getproperty.(metadata, :name)) == [:m, :Γ, :σ, :c1, :fs]
+    @test collect(getproperty.(metadata, :name)) == [:fs, :m, :Γ, :σ, :c1]
     @test collect(getproperty.(metadata, :parameter_type)) == [
+        AdvancedParameter,
         FlexibleParameter,
         FlexibleParameter,
         Running,
         FlexibleParameter,
-        AdvancedParameter,
     ]
-    @test parameter_names(metadata) == (:m, :Γ, :σ, :c1, :fs)
+    @test parameter_names(metadata) == (:fs, :m, :Γ, :σ, :c1)
     @test isequal(parameter_values(metadata), parameter_values(constructor))
     @test !any(==(Any), fieldtypes(typeof(parameter_values(metadata))))
 
     fix!(constructor, (:m, :fs))
     metadata = parameter_metadata(constructor)
     @test running_names(metadata) == (:Γ, :σ, :c1)
-    @test fixed_names(metadata) == (:m, :fs)
+    @test fixed_names(metadata) == (:fs, :m)
     @test isequal(running_values(metadata), running_values(constructor))
     @test isequal(fixed_values(metadata), fixed_values(constructor))
 end
@@ -120,16 +120,16 @@ end
     fix!(constructor, (:m, :c1, :fs))
 
     @test isequal(running_values(constructor), (Γ = 0.2, σ = missing))
-    @test isequal(fixed_values(constructor), (m = 2.0, c1 = 0.3, fs = 0.5))
+    @test isequal(fixed_values(constructor), (fs = 0.5, m = 2.0, c1 = 0.3))
 
     @test isequal(running_uncertainties(constructor), (Γ = missing, σ = missing))
-    @test isequal(fixed_uncertainties(constructor), (m = missing, c1 = missing, fs = 0.01))
+    @test isequal(fixed_uncertainties(constructor), (fs = 0.01, m = missing, c1 = missing))
 
     @test running_upper_boundaries(constructor) == (Γ = Inf, σ = Inf)
-    @test fixed_upper_boundaries(constructor) == (m = Inf, c1 = Inf, fs = 1.0)
+    @test fixed_upper_boundaries(constructor) == (fs = 1.0, m = Inf, c1 = Inf)
 
     @test running_lower_boundaries(constructor) == (Γ = -Inf, σ = -Inf)
-    @test fixed_lower_boundaries(constructor) == (m = -Inf, c1 = -Inf, fs = 0.0)
+    @test fixed_lower_boundaries(constructor) == (fs = 0.0, m = -Inf, c1 = -Inf)
 end
 
 @testset "shared parameter names do not break filtered collectors" begin
@@ -178,10 +178,9 @@ end
     @test parameter_uncertainties(f) == NamedTuple()
 
     # Test on constructor - should collect from all fields
-    # The constructor has: FlexibleParameter("m"), FlexibleParameter("Γ"), Fixed(0.0), Running("σ"), FlexibleParameter("c1"), FlexibleParameter("fs")
-    # Only Running("σ") should contribute
+    # The constructor has: AdvancedParameter("fs"), FlexibleParameter("m"), FlexibleParameter("Γ"), Running("σ"), FlexibleParameter("c1")
     @test parameter_uncertainties(constructor) ===
-          (m = missing, Γ = missing, σ = missing, c1 = missing, fs = 0.01)
+          (fs = 0.01, m = missing, Γ = missing, σ = missing, c1 = missing)
     @test keys(parameter_uncertainties(constructor)) == parameter_names(constructor)
 end
 
@@ -199,8 +198,7 @@ end
     @test parameter_upper_boundaries(f) == NamedTuple()
 
     # Test on constructor - should collect from all fields
-    # The constructor has: FlexibleParameter("m"), FlexibleParameter("Γ"), Fixed(0.0), Running("σ"), FlexibleParameter("c1"), FlexibleParameter("fs")
-    # All FlexibleParameters and Running should contribute with Inf
+    # The constructor has: AdvancedParameter("fs"), FlexibleParameter("m"), FlexibleParameter("Γ"), Running("σ"), FlexibleParameter("c1")
     upper_bounds = parameter_upper_boundaries(constructor)
     @test keys(upper_bounds) == keys(parameter_values(constructor))
     @test upper_bounds.m == Inf
@@ -208,7 +206,7 @@ end
     @test upper_bounds.σ == Inf
     @test upper_bounds.c1 == Inf
     @test upper_bounds.fs == 1.0
-    @test keys(upper_bounds) == (:m, :Γ, :σ, :c1, :fs)
+    @test keys(upper_bounds) == (:fs, :m, :Γ, :σ, :c1)
 
     p_default = AdvancedParameter("advanced", 1.0)
     @test parameter_upper_boundaries(p_default) == (advanced = Inf,)
@@ -237,7 +235,7 @@ end
     @test lower_bounds.σ == -Inf
     @test lower_bounds.c1 == -Inf
     @test lower_bounds.fs == 0.0
-    @test keys(lower_bounds) == (:m, :Γ, :σ, :c1, :fs)
+    @test keys(lower_bounds) == (:fs, :m, :Γ, :σ, :c1)
 
     p_default = AdvancedParameter("advanced", 1.0)
     @test parameter_lower_boundaries(p_default) == (advanced = -Inf,)


### PR DESCRIPTION
## Summary
- `@with_parameters` now emits struct fields and constructor positional arguments in macro header declaration order instead of reordering by field kind (parametric → descriptor → constant).
- Updates `ConstructorOfPRBModel` call sites, deserialization, and parameter-metadata test expectations affected by the new field order.
- Closes #39.

## Test plan
- [x] `Pkg.test("BuildConstructors")` passes locally
- [x] Added regression test asserting `fieldnames` match declaration order for mixed field kinds
- [ ] Confirm downstream code constructing `ConstructorOfPRBModel` with the old reordered argument list is updated if needed

Made with [Cursor](https://cursor.com)