### PR TITLE
Add fixed keyword to AdvancedParameter constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The package includes a few ready-to-use descriptors:
 | `Fixed(value)` | A constant value that is not collected as a named parameter. |
 | `Running(name)` | A free parameter read from `pars` by name. |
 | `FlexibleParameter(name, value)` | A parameter with a stored value that can be fixed or released. |
-| `AdvancedParameter(name, value; boundaries, uncertainty)` | A parameter with a stored value, bounds, uncertainty, and fixed/free state. |
+| `AdvancedParameter(name, value; boundaries, uncertainty, fixed)` | A parameter with a stored value, bounds, uncertainty, and fixed/free state. |
 
 The same generic tools work recursively on constructors and nested constructors:
 

--- a/src/concrete-parameters.jl
+++ b/src/concrete-parameters.jl
@@ -124,7 +124,7 @@ parameter_metadata(c::FlexibleParameter) =
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # advanced parameter, can be fixed and released, and has boundaries and uncertainty
 """
-    AdvancedParameter(name, value; boundaries = (-Inf, Inf), uncertainty = 1.0)
+    AdvancedParameter(name, value; boundaries = (-Inf, Inf), uncertainty = 1.0, fixed = false)
     AdvancedParameter(name, value, boundaries, uncertainty, fixed)
 
 Mutable parameter descriptor with stored value, bounds, uncertainty, and
@@ -151,12 +151,12 @@ Resolve to the stored value when `p.fixed` is true; otherwise read `p.name` from
 value(p::AdvancedParameter; pars) = p.fixed ? p.value : getproperty(pars, Symbol(p.name))
 
 """
-    AdvancedParameter(name, value; boundaries = (-Inf, Inf), uncertainty = 1.0)
+    AdvancedParameter(name, value; boundaries = (-Inf, Inf), uncertainty = 1.0, fixed = false)
 
-Create a free `AdvancedParameter` with stored value, bounds, and uncertainty.
+Create an `AdvancedParameter` with stored value, bounds, uncertainty, and fixed/free state.
 """
-AdvancedParameter(name, value; boundaries = (-Inf, Inf), uncertainty = 1.0) =
-    AdvancedParameter(name, value, boundaries, uncertainty, false)
+AdvancedParameter(name, value; boundaries = (-Inf, Inf), uncertainty = 1.0, fixed = false) =
+    AdvancedParameter(name, value, boundaries, uncertainty, fixed)
 
 """
     fix!(p::AdvancedParameter, par_names)

--- a/test/test-parameter.jl
+++ b/test/test-parameter.jl
@@ -19,6 +19,10 @@ constructor = ConstructorOfPRBModel(
     @test getfield(constructor.model_p.description_of_m, :fixed) == false
 end
 
+@testset "AdvancedParameter fixed keyword" begin
+    @test AdvancedParameter("x", 1.0).fixed == false
+    @test AdvancedParameter("x", 1.0; fixed = true).fixed == true
+end
 
 # tests
 @testset "fix and release, one argument" begin


### PR DESCRIPTION
## Summary
- Expose `fixed = false` on the `AdvancedParameter` keyword constructor so initial fixed/free state can be set without the positional 5-argument form.
- Update docstrings and README to document the new keyword.
- Add a small test covering default and `fixed = true` construction.

Closes #46

## Test plan
- [x] `Pkg.test("BuildConstructors"; test_args=\`test-parameter\`)`

Made with [Cursor](https://cursor.com)