### PR TITLE
Document running bounds and uncertainties for fitting workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,11 @@ Define your own by subtyping `AbstractParameter` and implementing `value(p; pars
 
 ## Metadata API
 
+Collectors come in three families: `parameter_*` (all named parameters),
+`running_*` (free parameters only — use these for fitting), and `fixed_*`
+(fixed parameters only). When nothing is fixed, `parameter_*` and `running_*`
+agree.
+
 These methods recurse into nested `AbstractConstructor` fields:
 
 ```julia

--- a/README.md
+++ b/README.md
@@ -85,13 +85,26 @@ constructor = ConstructorOfMixture(
     AdvancedParameter("f_left", 0.5; boundaries=(0.0, 1.0), uncertainty=0.02),
 )
 
-start = parameter_values(constructor)
-lower = parameter_lower_boundaries(constructor)
-upper = parameter_upper_boundaries(constructor)
+start = running_values(constructor)
+lower = running_lower_boundaries(constructor)
+upper = running_upper_boundaries(constructor)
+uncertainties = running_uncertainties(constructor)
 ```
 
-Nested constructors are discovered automatically — `parameter_values` walks the
-whole tree and returns one named tuple of running parameters.
+Nested constructors are discovered automatically. The `running_*` collectors walk
+the whole tree and return only the parameters that are currently free. After
+`fix!(constructor, (:μ_left,))`, the fit vector shrinks automatically:
+
+```julia
+fix!(constructor, (:μ_left,))
+running_values(constructor)              # no longer includes μ_left
+running_lower_boundaries(constructor)
+running_upper_boundaries(constructor)
+running_uncertainties(constructor)
+```
+
+Use `parameter_values` and the other `parameter_*` collectors when you need
+metadata for every named descriptor, including fixed ones.
 
 ### 3. Optimize: `build_model` produces whatever you need
 
@@ -143,11 +156,21 @@ These methods recurse into nested `AbstractConstructor` fields:
 parameter_metadata(constructor)
 parameter_values(constructor)
 parameter_names(constructor)
-running_names(constructor)
-fixed_names(constructor)
 parameter_uncertainties(constructor)
 parameter_lower_boundaries(constructor)
 parameter_upper_boundaries(constructor)
+
+running_names(constructor)
+running_values(constructor)
+running_uncertainties(constructor)
+running_lower_boundaries(constructor)
+running_upper_boundaries(constructor)
+
+fixed_names(constructor)
+fixed_values(constructor)
+fixed_uncertainties(constructor)
+fixed_lower_boundaries(constructor)
+fixed_upper_boundaries(constructor)
 
 fix!(constructor, (:σ,))
 release!(constructor, (:σ,))

--- a/docs/src/tutorials/minuit2-componentarrays.md
+++ b/docs/src/tutorials/minuit2-componentarrays.md
@@ -44,18 +44,22 @@ truth = MixtureModel([Normal(-1.0, 0.45), Normal(1.2, 0.35)], [0.6, 0.4])
 data = rand(truth, 2_000)
 ```
 
-Prepare the starting point and metadata:
+Prepare the starting point and metadata. The `running_*` collectors keep fixed
+parameters out of the Minuit vector:
 
 ```julia
-start = ComponentArray(parameter_values(constructor))
-lower = ComponentArray(parameter_lower_boundaries(constructor))
-upper = ComponentArray(parameter_upper_boundaries(constructor))
+start = ComponentArray(running_values(constructor))
+lower = ComponentArray(running_lower_boundaries(constructor))
+upper = ComponentArray(running_upper_boundaries(constructor))
 
 errors = ComponentArray(
-    map(v -> coalesce(v, 0.1), parameter_uncertainties(constructor)),
+    map(v -> coalesce(v, 0.1), running_uncertainties(constructor)),
 )
 limits = collect(zip(lower, upper))
 ```
+
+After `fix!(constructor, (:μ_left,))`, rerun the collectors above to rebuild
+`start`, `lower`, `upper`, and `errors` for the smaller free subset.
 
 The `coalesce` call gives Minuit a finite step size even if a descriptor has no
 stored uncertainty and reports `missing`.

--- a/docs/src/tutorials/optim-componentarrays.md
+++ b/docs/src/tutorials/optim-componentarrays.md
@@ -46,12 +46,21 @@ truth = MixtureModel([Normal(-1.0, 0.45), Normal(1.2, 0.35)], [0.6, 0.4])
 data = rand(truth, 2_000)
 ```
 
-Convert the constructor metadata to `ComponentArray`s:
+Convert the constructor metadata to `ComponentArray`s. Use the `running_*`
+collectors so fixed parameters stay out of the optimizer input:
 
 ```julia
-start = ComponentArray(parameter_values(constructor))
-lower = ComponentArray(parameter_lower_boundaries(constructor))
-upper = ComponentArray(parameter_upper_boundaries(constructor))
+start = ComponentArray(running_values(constructor))
+lower = ComponentArray(running_lower_boundaries(constructor))
+upper = ComponentArray(running_upper_boundaries(constructor))
+```
+
+If some parameters should stay fixed during the fit, call `fix!` first. The
+running collectors shrink to the free subset:
+
+```julia
+fix!(constructor, (:μ_left,))
+start = ComponentArray(running_values(constructor))
 ```
 
 The negative log-likelihood can pass the `ComponentArray` directly into


### PR DESCRIPTION
## Summary
- Switch README and optimizer tutorials to `running_values`, `running_lower_boundaries`, `running_upper_boundaries`, and `running_uncertainties` when preparing fit inputs.
- Document the `fix!` workflow where running collectors shrink to the free parameter subset.
- Expand the README Metadata API section to list the running and fixed collector families explicitly.

Fixes #52.

## Test plan
- [x] Documentation-only change; no code behavior changed.
- [x] Verified existing tests still pass locally (`Pkg.test()`).


Made with [Cursor](https://cursor.com)