### PR TITLE
Add overhead benchmark suite

### DIFF
--- a/benchmark/.gitignore
+++ b/benchmark/.gitignore
@@ -1,0 +1,1 @@
+results.txt

--- a/benchmark/Manifest.toml
+++ b/benchmark/Manifest.toml
@@ -1,0 +1,874 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.11.5"
+manifest_format = "2.0"
+project_hash = "81e0ba2132bc9944f6efb262cd646fb05e9fc622"
+
+[[deps.AbstractFFTs]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "d92ad398961a3ed262d8bf04a1a2b8340f915fef"
+uuid = "621f4979-c628-5d54-868e-fcf4e3e8185c"
+version = "1.5.0"
+weakdeps = ["ChainRulesCore", "Test"]
+
+    [deps.AbstractFFTs.extensions]
+    AbstractFFTsChainRulesCoreExt = "ChainRulesCore"
+    AbstractFFTsTestExt = "Test"
+
+[[deps.Accessors]]
+deps = ["CompositionsBase", "ConstructionBase", "Dates", "InverseFunctions", "MacroTools"]
+git-tree-sha1 = "7063ad1083578215c7c4bf410368150abe8d5524"
+uuid = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
+version = "0.1.45"
+
+    [deps.Accessors.extensions]
+    AxisKeysExt = "AxisKeys"
+    IntervalSetsExt = "IntervalSets"
+    LinearAlgebraExt = "LinearAlgebra"
+    StaticArraysExt = "StaticArrays"
+    StructArraysExt = "StructArrays"
+    TestExt = "Test"
+    UnitfulExt = "Unitful"
+
+    [deps.Accessors.weakdeps]
+    AxisKeys = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"
+    IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
+    LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+    StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+    Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[[deps.Adapt]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "daa72978cd7a624246e894a4f4f067706d4e17e2"
+uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+version = "4.7.0"
+weakdeps = ["SparseArrays", "StaticArrays"]
+
+    [deps.Adapt.extensions]
+    AdaptSparseArraysExt = "SparseArrays"
+    AdaptStaticArraysExt = "StaticArrays"
+
+[[deps.AliasTables]]
+deps = ["PtrArrays", "Random"]
+git-tree-sha1 = "9876e1e164b144ca45e9e3198d0b689cadfed9ff"
+uuid = "66dad0bd-aa9a-41b7-9441-69ab47430ed8"
+version = "1.1.3"
+
+[[deps.ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+version = "1.1.2"
+
+[[deps.ArrayInterface]]
+deps = ["Adapt", "LinearAlgebra"]
+git-tree-sha1 = "60f11b38ebeabd984f5535838d91e197d97202f0"
+uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
+version = "7.28.1"
+
+    [deps.ArrayInterface.extensions]
+    ArrayInterfaceAMDGPUExt = "AMDGPU"
+    ArrayInterfaceBandedMatricesExt = "BandedMatrices"
+    ArrayInterfaceBlockBandedMatricesExt = "BlockBandedMatrices"
+    ArrayInterfaceCUDAExt = "CUDA"
+    ArrayInterfaceCUDSSExt = ["CUDSS", "CUDA"]
+    ArrayInterfaceChainRulesCoreExt = "ChainRulesCore"
+    ArrayInterfaceChainRulesExt = "ChainRules"
+    ArrayInterfaceFillArraysExt = "FillArrays"
+    ArrayInterfaceGPUArraysCoreExt = "GPUArraysCore"
+    ArrayInterfaceMetalExt = "Metal"
+    ArrayInterfaceReverseDiffExt = "ReverseDiff"
+    ArrayInterfaceSparseArraysExt = "SparseArrays"
+    ArrayInterfaceStaticArraysCoreExt = "StaticArraysCore"
+    ArrayInterfaceTrackerExt = "Tracker"
+
+    [deps.ArrayInterface.weakdeps]
+    AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
+    BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
+    BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"
+    CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+    CUDSS = "45b445bb-4962-46a0-9369-b4df9d0f772e"
+    ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
+    GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
+    Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
+    ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+    StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+    Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
+
+[[deps.AxisAlgorithms]]
+deps = ["LinearAlgebra", "Random", "SparseArrays", "WoodburyMatrices"]
+git-tree-sha1 = "01b8ccb13d68535d73d2b0c23e39bd23155fb712"
+uuid = "13072b0f-2c55-5437-9ae7-d433b7a33950"
+version = "1.1.0"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+version = "1.11.0"
+
+[[deps.BenchmarkTools]]
+deps = ["Compat", "JSON", "Logging", "PrecompileTools", "Printf", "Profile", "Statistics", "UUIDs"]
+git-tree-sha1 = "9670d3febc2b6da60a0ae57846ba74670290653f"
+uuid = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+version = "1.8.0"
+
+[[deps.BuildConstructors]]
+deps = ["OrderedCollections"]
+path = ".."
+uuid = "63b9b590-f22f-4e79-810f-ea9ba6849c26"
+version = "0.7.0"
+weakdeps = ["Distributions", "DistributionsHEP", "JSON", "NumericalDistributions"]
+
+    [deps.BuildConstructors.extensions]
+    PhysicsModelsExt = ["Distributions", "DistributionsHEP", "JSON", "NumericalDistributions"]
+
+[[deps.ChainRulesCore]]
+deps = ["Compat", "LinearAlgebra"]
+git-tree-sha1 = "12177ad6b3cad7fd50c8b3825ce24a99ad61c18f"
+uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+version = "1.26.1"
+weakdeps = ["SparseArrays"]
+
+    [deps.ChainRulesCore.extensions]
+    ChainRulesCoreSparseArraysExt = "SparseArrays"
+
+[[deps.CommonSolve]]
+git-tree-sha1 = "cf963add2340ad9960e5eb22844e61ad8f931fe1"
+uuid = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
+version = "0.2.13"
+
+[[deps.CommonWorldInvalidations]]
+git-tree-sha1 = "ef2022bff55342a8c9846cdf218f62e475f0444d"
+uuid = "f70d9fcc-98c5-4d4a-abd7-e4cdeebd8ca8"
+version = "1.1.2"
+
+[[deps.Compat]]
+deps = ["TOML", "UUIDs"]
+git-tree-sha1 = "9d8a54ce4b17aa5bdce0ea5c34bc5e7c340d16ad"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "4.18.1"
+weakdeps = ["Dates", "LinearAlgebra"]
+
+    [deps.Compat.extensions]
+    CompatLinearAlgebraExt = "LinearAlgebra"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.1.1+0"
+
+[[deps.ComponentArrays]]
+deps = ["Adapt", "ArrayInterface", "ChainRulesCore", "ConstructionBase", "Functors", "LinearAlgebra", "StaticArrayInterface", "StaticArraysCore"]
+git-tree-sha1 = "122b5c26469f63d50d1e76f6c63428aa7d2b244b"
+uuid = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
+version = "0.15.44"
+
+    [deps.ComponentArrays.extensions]
+    ComponentArraysGPUArraysExt = "GPUArrays"
+    ComponentArraysKernelAbstractionsExt = "KernelAbstractions"
+    ComponentArraysMooncakeExt = "Mooncake"
+    ComponentArraysOptimisersExt = "Optimisers"
+    ComponentArraysReactantExt = "Reactant"
+    ComponentArraysRecursiveArrayToolsExt = "RecursiveArrayTools"
+    ComponentArraysReverseDiffExt = "ReverseDiff"
+    ComponentArraysSciMLBaseExt = ["SciMLBase", "SymbolicIndexingInterface"]
+    ComponentArraysTrackerExt = "Tracker"
+    ComponentArraysZygoteExt = "Zygote"
+
+    [deps.ComponentArrays.weakdeps]
+    GPUArrays = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
+    KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
+    Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
+    Optimisers = "3bd65402-5787-11e9-1adc-39752487f4e2"
+    Reactant = "3c362404-f566-11ee-1572-e11a4b42c853"
+    RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
+    ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
+    SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
+    SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
+    Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
+    Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+
+[[deps.CompositionsBase]]
+git-tree-sha1 = "802bb88cd69dfd1509f6670416bd4434015693ad"
+uuid = "a33af91c-f02d-484b-be07-31d278c5ca2b"
+version = "0.1.2"
+weakdeps = ["InverseFunctions"]
+
+    [deps.CompositionsBase.extensions]
+    CompositionsBaseInverseFunctionsExt = "InverseFunctions"
+
+[[deps.ConstructionBase]]
+git-tree-sha1 = "b4b092499347b18a015186eae3042f72267106cb"
+uuid = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
+version = "1.6.0"
+
+    [deps.ConstructionBase.extensions]
+    ConstructionBaseIntervalSetsExt = "IntervalSets"
+    ConstructionBaseLinearAlgebraExt = "LinearAlgebra"
+    ConstructionBaseStaticArraysExt = "StaticArrays"
+
+    [deps.ConstructionBase.weakdeps]
+    IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
+    LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+[[deps.DataAPI]]
+git-tree-sha1 = "abe83f3a2f1b857aac70ef8b269080af17764bbe"
+uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
+version = "1.16.0"
+
+[[deps.DataStructures]]
+deps = ["OrderedCollections"]
+git-tree-sha1 = "b0bc6d2cad1fed8b7fd59a1551a991cb3d2809e6"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.19.6"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
+
+[[deps.Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+version = "1.11.0"
+
+[[deps.Distributions]]
+deps = ["AliasTables", "FillArrays", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "Roots", "SpecialFunctions", "Statistics", "StatsAPI", "StatsBase", "StatsFuns"]
+git-tree-sha1 = "d2facc77c08c1c2bfb1a77c148edd05b3db5410b"
+uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
+version = "0.25.130"
+
+    [deps.Distributions.extensions]
+    DistributionsChainRulesCoreExt = "ChainRulesCore"
+    DistributionsDensityInterfaceExt = "DensityInterface"
+    DistributionsSparseConnectivityTracerExt = "SparseConnectivityTracer"
+    DistributionsTestExt = "Test"
+
+    [deps.Distributions.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    DensityInterface = "b429d917-457f-4dbc-8f4c-0cc954292b1d"
+    SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
+    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[deps.DistributionsHEP]]
+deps = ["Distributions", "Polynomials", "Random", "SpecialFunctions"]
+git-tree-sha1 = "ef35f9f549df0330c5c5a9425a61b4d632c8d5e7"
+uuid = "0d0d6f60-fb7b-48ca-90bb-e14e8b1655a7"
+version = "0.6.2"
+
+[[deps.DocStringExtensions]]
+git-tree-sha1 = "7442a5dfe1ebb773c29cc2962a8980f47221d76c"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.9.5"
+
+[[deps.Downloads]]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "1.6.0"
+
+[[deps.FFTW]]
+deps = ["AbstractFFTs", "FFTW_jll", "Libdl", "LinearAlgebra", "MKL_jll", "Preferences", "Reexport"]
+git-tree-sha1 = "97f08406df914023af55ade2f843c39e99c5d969"
+uuid = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+version = "1.10.0"
+
+[[deps.FFTW_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "6866aec60ef98e3164cd8d6855225684207e9dff"
+uuid = "f5851436-0d7a-5f13-b9de-f02708fd171a"
+version = "3.3.12+0"
+
+[[deps.FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+version = "1.11.0"
+
+[[deps.FillArrays]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "5bad39456d9f0166184fce2248783dd9862645c1"
+uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
+version = "1.17.0"
+weakdeps = ["PDMats", "SparseArrays", "StaticArrays", "Statistics"]
+
+    [deps.FillArrays.extensions]
+    FillArraysPDMatsExt = "PDMats"
+    FillArraysSparseArraysExt = "SparseArrays"
+    FillArraysStaticArraysExt = "StaticArrays"
+    FillArraysStatisticsExt = "Statistics"
+
+[[deps.Functors]]
+deps = ["Compat", "ConstructionBase", "LinearAlgebra", "Random"]
+git-tree-sha1 = "1ac2813982db52b974c9343124ca61adbf297316"
+uuid = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
+version = "0.5.3"
+
+[[deps.Future]]
+deps = ["Random"]
+uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
+version = "1.11.0"
+
+[[deps.Gamma]]
+git-tree-sha1 = "86f86b6168a016ed88e4ae4e64577b98c3b59e8e"
+uuid = "a0844989-3bd2-4988-8bea-c9407ab0941b"
+version = "1.1.0"
+
+[[deps.HypergeometricFunctions]]
+deps = ["Gamma", "LinearAlgebra"]
+git-tree-sha1 = "31bb6c92405c084617facc1d7ed9eb6c402d061e"
+uuid = "34004b35-14d8-5ef3-9330-4cdb6864b03a"
+version = "0.3.30"
+
+[[deps.IfElse]]
+git-tree-sha1 = "debdd00ffef04665ccbb3e150747a77560e8fad1"
+uuid = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"
+version = "0.1.1"
+
+[[deps.IntelOpenMP_jll]]
+deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl"]
+git-tree-sha1 = "ec1debd61c300961f98064cfb21287613ad7f303"
+uuid = "1d5cc7b8-4909-519e-a0f8-d0f5ad9712d0"
+version = "2025.2.0+0"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+version = "1.11.0"
+
+[[deps.Interpolations]]
+deps = ["Adapt", "AxisAlgorithms", "ChainRulesCore", "LinearAlgebra", "OffsetArrays", "Random", "Ratios", "Requires", "SharedArrays", "SparseArrays", "StaticArrays", "WoodburyMatrices"]
+git-tree-sha1 = "88a101217d7cb38a7b481ccd50d21876e1d1b0e0"
+uuid = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
+version = "0.15.1"
+
+    [deps.Interpolations.extensions]
+    InterpolationsUnitfulExt = "Unitful"
+
+    [deps.Interpolations.weakdeps]
+    Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[[deps.InverseFunctions]]
+git-tree-sha1 = "a779299d77cd080bf77b97535acecd73e1c5e5cb"
+uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
+version = "0.1.17"
+weakdeps = ["Dates", "Test"]
+
+    [deps.InverseFunctions.extensions]
+    InverseFunctionsDatesExt = "Dates"
+    InverseFunctionsTestExt = "Test"
+
+[[deps.IrrationalConstants]]
+git-tree-sha1 = "b2d91fe939cae05960e760110b328288867b5758"
+uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
+version = "0.2.6"
+
+[[deps.JLLWrappers]]
+deps = ["Artifacts", "Preferences"]
+git-tree-sha1 = "7204148362dafe5fe6a273f855b8ccbe4df8173e"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.8.0"
+
+[[deps.JSON]]
+deps = ["Dates", "Logging", "Parsers", "PrecompileTools", "StructUtils", "UUIDs", "Unicode"]
+git-tree-sha1 = "65979512c25a0727f050e6e4be40f0fd9ec893f7"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "1.7.0"
+
+    [deps.JSON.extensions]
+    JSONArrowExt = ["ArrowTypes"]
+
+    [deps.JSON.weakdeps]
+    ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
+
+[[deps.LazyArtifacts]]
+deps = ["Artifacts", "Pkg"]
+uuid = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
+version = "1.11.0"
+
+[[deps.LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "0.6.4"
+
+[[deps.LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "8.6.0+0"
+
+[[deps.LibGit2]]
+deps = ["Base64", "LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+version = "1.11.0"
+
+[[deps.LibGit2_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
+uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
+version = "1.7.2+0"
+
+[[deps.LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.11.0+1"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+version = "1.11.0"
+
+[[deps.LinearAlgebra]]
+deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+version = "1.11.0"
+
+[[deps.LogExpFunctions]]
+deps = ["DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
+git-tree-sha1 = "bba2d9aa057d8f126415de240573e86a8f39d2a1"
+uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
+version = "1.0.1"
+
+    [deps.LogExpFunctions.extensions]
+    LogExpFunctionsChainRulesCoreExt = "ChainRulesCore"
+    LogExpFunctionsChangesOfVariablesExt = "ChangesOfVariables"
+    LogExpFunctionsInverseFunctionsExt = "InverseFunctions"
+
+    [deps.LogExpFunctions.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    ChangesOfVariables = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
+    InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+version = "1.11.0"
+
+[[deps.MKL_jll]]
+deps = ["Artifacts", "IntelOpenMP_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "oneTBB_jll"]
+git-tree-sha1 = "282cadc186e7b2ae0eeadbd7a4dffed4196ae2aa"
+uuid = "856f044c-d86e-5d09-b602-aeab76dc8ba7"
+version = "2025.2.0+0"
+
+[[deps.MacroTools]]
+git-tree-sha1 = "1e0228a030642014fe5cfe68c2c0a818f9e3f522"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.5.16"
+
+[[deps.Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+version = "1.11.0"
+
+[[deps.MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+version = "2.28.6+0"
+
+[[deps.Missings]]
+deps = ["DataAPI"]
+git-tree-sha1 = "ec4f7fbeab05d7747bdf98eb74d130a2a2ed298d"
+uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
+version = "1.2.0"
+
+[[deps.Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+version = "1.11.0"
+
+[[deps.MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2023.12.12"
+
+[[deps.NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.2.0"
+
+[[deps.NumericalDistributions]]
+deps = ["Distributions", "FFTW", "Interpolations", "Parameters", "QuadGK", "Random", "Test"]
+git-tree-sha1 = "48ad397abb5b85508addae78a89f1fd143c06a59"
+uuid = "13416b18-ec19-40e4-a123-e345ab61da74"
+version = "0.5.3"
+
+[[deps.OffsetArrays]]
+git-tree-sha1 = "117432e406b5c023f665fa73dc26e79ec3630151"
+uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+version = "1.17.0"
+weakdeps = ["Adapt"]
+
+    [deps.OffsetArrays.extensions]
+    OffsetArraysAdaptExt = "Adapt"
+
+[[deps.OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+version = "0.3.27+1"
+
+[[deps.OpenLibm_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
+version = "0.8.5+0"
+
+[[deps.OpenSpecFun_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "1346c9208249809840c91b26703912dff463d335"
+uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
+version = "0.5.6+0"
+
+[[deps.OrderedCollections]]
+git-tree-sha1 = "94ba93778373a53bfd5a0caaf7d809c445292ff4"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.8.2"
+
+[[deps.PDMats]]
+deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]
+git-tree-sha1 = "123266c25174ef6c8d4718920abc206452cf8de6"
+uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
+version = "0.11.41"
+weakdeps = ["StatsBase"]
+
+    [deps.PDMats.extensions]
+    StatsBaseExt = "StatsBase"
+
+[[deps.Parameters]]
+deps = ["OrderedCollections", "UnPack"]
+git-tree-sha1 = "34c0e9ad262e5f7fc75b10a9952ca7692cfc5fbe"
+uuid = "d96e819e-fc66-5662-9728-84c9c7592b0a"
+version = "0.12.3"
+
+[[deps.Parsers]]
+deps = ["Dates", "PrecompileTools", "UUIDs"]
+git-tree-sha1 = "3de8f5e6e90ebfa8d6d1f86997d6cdcd6a912ff3"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "2.8.7"
+
+[[deps.Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+version = "1.11.0"
+
+    [deps.Pkg.extensions]
+    REPLExt = "REPL"
+
+    [deps.Pkg.weakdeps]
+    REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[deps.Polynomials]]
+deps = ["LinearAlgebra", "OrderedCollections", "Setfield", "SparseArrays"]
+git-tree-sha1 = "2d99b4c8a7845ab1342921733fa29366dae28b24"
+uuid = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
+version = "4.1.1"
+
+    [deps.Polynomials.extensions]
+    PolynomialsChainRulesCoreExt = "ChainRulesCore"
+    PolynomialsFFTWExt = "FFTW"
+    PolynomialsMakieExt = "Makie"
+    PolynomialsMutableArithmeticsExt = "MutableArithmetics"
+    PolynomialsRecipesBaseExt = "RecipesBase"
+
+    [deps.Polynomials.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+    Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+    MutableArithmetics = "d8a4904e-b15c-11e9-3269-09a3773c0cb0"
+    RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "5aa36f7049a63a1528fe8f7c3f2113413ffd4e1f"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.2.1"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "8b770b60760d4451834fe79dd483e318eee709c4"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.5.2"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
+
+[[deps.Profile]]
+uuid = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
+version = "1.11.0"
+
+[[deps.PtrArrays]]
+git-tree-sha1 = "4fbbafbc6251b883f4d2705356f3641f3652a7fe"
+uuid = "43287f4e-b6f4-7ad1-bb20-aadabca52c3d"
+version = "1.4.0"
+
+[[deps.QuadGK]]
+deps = ["DataStructures", "LinearAlgebra"]
+git-tree-sha1 = "5e8e8b0ab68215d7a2b14b9921a946fee794749e"
+uuid = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
+version = "2.11.3"
+
+    [deps.QuadGK.extensions]
+    QuadGKEnzymeExt = "Enzyme"
+
+    [deps.QuadGK.weakdeps]
+    Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+
+[[deps.Random]]
+deps = ["SHA"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
+
+[[deps.Ratios]]
+deps = ["Requires"]
+git-tree-sha1 = "1342a47bf3260ee108163042310d26f2be5ec90b"
+uuid = "c84ed2f1-dad5-54f0-aa8e-dbefe2724439"
+version = "0.4.5"
+
+    [deps.Ratios.extensions]
+    RatiosFixedPointNumbersExt = "FixedPointNumbers"
+
+    [deps.Ratios.weakdeps]
+    FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
+
+[[deps.Reexport]]
+git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
+uuid = "189a3867-3050-52da-a836-e630ba90ab69"
+version = "1.2.2"
+
+[[deps.Requires]]
+deps = ["UUIDs"]
+git-tree-sha1 = "62389eeff14780bfe55195b7204c0d8738436d64"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "1.3.1"
+
+[[deps.Rmath]]
+deps = ["Random", "Rmath_jll"]
+git-tree-sha1 = "5b3d50eb374cea306873b371d3f8d3915a018f0b"
+uuid = "79098fc4-a85e-5d69-aa6a-4863f24498fa"
+version = "0.9.0"
+
+[[deps.Rmath_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "6d40b2fe70437b01397d2a4d5b020008da4e7019"
+uuid = "f50d1b31-88e8-58de-be2c-1cc44531875f"
+version = "0.5.2+0"
+
+[[deps.Roots]]
+deps = ["Accessors", "CommonSolve", "Printf"]
+git-tree-sha1 = "7fb25a964849d90a0446366cdefca822e0e84900"
+uuid = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
+version = "3.0.6"
+
+    [deps.Roots.extensions]
+    RootsChainRulesCoreExt = "ChainRulesCore"
+    RootsForwardDiffExt = "ForwardDiff"
+    RootsIntervalRootFindingExt = "IntervalRootFinding"
+    RootsSymPyExt = "SymPy"
+    RootsSymPyPythonCallExt = "SymPyPythonCall"
+    RootsUnitfulExt = "Unitful"
+
+    [deps.Roots.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+    IntervalRootFinding = "d2bf35a9-74e0-55ec-b149-d360ff49b807"
+    SymPy = "24249f21-da20-56a4-8eb1-6a02cf4ae2e6"
+    SymPyPythonCall = "bc8888f7-b21e-4b7c-a06a-5d9c9496438c"
+    Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+
+[[deps.SciMLPublic]]
+git-tree-sha1 = "cf9aaf8b9ed5db993259ea8b24cf2b7ba9bd3b79"
+uuid = "431bcebd-1456-4ced-9d72-93c2757fff0b"
+version = "1.2.4"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+version = "1.11.0"
+
+[[deps.Setfield]]
+deps = ["ConstructionBase", "Future", "MacroTools", "StaticArraysCore"]
+git-tree-sha1 = "c5391c6ace3bc430ca630251d02ea9687169ca68"
+uuid = "efcf1570-3423-57d1-acb7-fd33fddbac46"
+version = "1.1.2"
+
+[[deps.SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+version = "1.11.0"
+
+[[deps.Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+version = "1.11.0"
+
+[[deps.SortingAlgorithms]]
+deps = ["DataStructures"]
+git-tree-sha1 = "13cd91cc9be159e3f4d95b857fa2aa383b53772a"
+uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
+version = "1.2.3"
+
+[[deps.SparseArrays]]
+deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+version = "1.11.0"
+
+[[deps.SpecialFunctions]]
+deps = ["IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
+git-tree-sha1 = "c3ac026e735264e9bdc6a9bcbd1b1e781b36e3bc"
+uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
+version = "2.8.3"
+weakdeps = ["ChainRulesCore"]
+
+    [deps.SpecialFunctions.extensions]
+    SpecialFunctionsChainRulesCoreExt = "ChainRulesCore"
+
+[[deps.Static]]
+deps = ["CommonWorldInvalidations", "IfElse", "PrecompileTools", "SciMLPublic"]
+git-tree-sha1 = "474a5283ad435618090122872eea6a8165ea6bcf"
+uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
+version = "1.4.6"
+
+[[deps.StaticArrayInterface]]
+deps = ["ArrayInterface", "Compat", "IfElse", "LinearAlgebra", "PrecompileTools", "SciMLPublic", "Static"]
+git-tree-sha1 = "2a635e15d5035c53b345077c947f31ff91744078"
+uuid = "0d7ed370-da01-4f52-bd93-41d350b8b718"
+version = "1.10.0"
+weakdeps = ["OffsetArrays", "StaticArrays"]
+
+    [deps.StaticArrayInterface.extensions]
+    StaticArrayInterfaceOffsetArraysExt = "OffsetArrays"
+    StaticArrayInterfaceStaticArraysExt = "StaticArrays"
+
+[[deps.StaticArrays]]
+deps = ["LinearAlgebra", "PrecompileTools", "Random", "StaticArraysCore"]
+git-tree-sha1 = "246a8bb2e6667f832eea063c3a56aef96429a3db"
+uuid = "90137ffa-7385-5640-81b9-e52037218182"
+version = "1.9.18"
+weakdeps = ["ChainRulesCore", "Statistics"]
+
+    [deps.StaticArrays.extensions]
+    StaticArraysChainRulesCoreExt = "ChainRulesCore"
+    StaticArraysStatisticsExt = "Statistics"
+
+[[deps.StaticArraysCore]]
+git-tree-sha1 = "6ab403037779dae8c514bad259f32a447262455a"
+uuid = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+version = "1.4.4"
+
+[[deps.Statistics]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "ae3bb1eb3bba077cd276bc5cfc337cc65c3075c0"
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+version = "1.11.1"
+weakdeps = ["SparseArrays"]
+
+    [deps.Statistics.extensions]
+    SparseArraysExt = ["SparseArrays"]
+
+[[deps.StatsAPI]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "178ed29fd5b2a2cfc3bd31c13375ae925623ff36"
+uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
+version = "1.8.0"
+
+[[deps.StatsBase]]
+deps = ["AliasTables", "DataAPI", "DataStructures", "IrrationalConstants", "LinearAlgebra", "LogExpFunctions", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "StatsAPI"]
+git-tree-sha1 = "e4d7a1a0edc20af42689ea6f4f3587a2175d50ee"
+uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+version = "0.34.12"
+
+[[deps.StatsFuns]]
+deps = ["HypergeometricFunctions", "IrrationalConstants", "LogExpFunctions", "Reexport", "Rmath", "SpecialFunctions"]
+git-tree-sha1 = "91a5737baed20ee31f3faea0e51f57461f6a689e"
+uuid = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
+version = "2.2.1"
+weakdeps = ["ChainRulesCore", "InverseFunctions"]
+
+    [deps.StatsFuns.extensions]
+    StatsFunsChainRulesCoreExt = "ChainRulesCore"
+    StatsFunsInverseFunctionsExt = "InverseFunctions"
+
+[[deps.StructUtils]]
+deps = ["Dates", "UUIDs"]
+git-tree-sha1 = "a99e557661bfcee04af1ba688ab6c211b25327f9"
+uuid = "ec057cc2-7a8d-4b58-b3b3-92acb9f63b42"
+version = "2.8.3"
+
+    [deps.StructUtils.extensions]
+    StructUtilsMeasurementsExt = ["Measurements"]
+    StructUtilsStaticArraysCoreExt = ["StaticArraysCore"]
+    StructUtilsTablesExt = ["Tables"]
+
+    [deps.StructUtils.weakdeps]
+    Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
+    StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+    Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+
+[[deps.SuiteSparse]]
+deps = ["Libdl", "LinearAlgebra", "Serialization", "SparseArrays"]
+uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
+
+[[deps.SuiteSparse_jll]]
+deps = ["Artifacts", "Libdl", "libblastrampoline_jll"]
+uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
+version = "7.7.0+0"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[deps.Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+version = "1.10.0"
+
+[[deps.Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+version = "1.11.0"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+version = "1.11.0"
+
+[[deps.UnPack]]
+git-tree-sha1 = "387c1f73762231e86e0c9c5443ce3b4a0a9a0c2b"
+uuid = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
+version = "1.0.2"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"
+
+[[deps.WoodburyMatrices]]
+deps = ["LinearAlgebra", "SparseArrays"]
+git-tree-sha1 = "248a7031b3da79a127f14e5dc5f417e26f9f6db7"
+uuid = "efce3f68-66dc-5838-9240-27a6d6f5f9b6"
+version = "1.1.0"
+
+[[deps.Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.2.13+1"
+
+[[deps.libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+version = "5.11.0+0"
+
+[[deps.nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+version = "1.59.0+0"
+
+[[deps.oneTBB_jll]]
+deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl"]
+git-tree-sha1 = "da8c1f6eee04831f14edcfa5dae611d309807e57"
+uuid = "1317d2d5-d96f-522e-a858-c73665f53c3e"
+version = "2022.3.0+0"
+
+[[deps.p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+version = "17.4.0+2"

--- a/benchmark/OVERHEAD.md
+++ b/benchmark/OVERHEAD.md
@@ -2,6 +2,52 @@
 
 BuildConstructors keeps fit metadata (names, bounds, fixed/free state) in a **constructor tree** and builds the domain model on demand via `build_model(constructor, pars)`. The question for fitting is: how much does that indirection cost at runtime and in memory?
 
+## Where overhead comes from
+
+BuildConstructors does not wrap the built model or intercept PDF calls. All extra work happens **inside `build_model`** (and, if misused, in metadata collectors). The main sources:
+
+### 1. Parameter lookup from `pars`
+
+Running parameters are resolved by name. The macro-generated body starts with lines like `μ = value(c.description_of_μ; pars)`, and built-in descriptors implement:
+
+```julia
+value(p::Running; pars) = getproperty(pars, Symbol(p.name))
+value(p::Fixed; pars) = p.value   # ignores pars
+```
+
+**What this means in practice:**
+
+- **`Fixed` parameters** read a stored `Float64` — no `pars` access, essentially free.
+- **`Running` / free `FlexibleParameter` / free `AdvancedParameter`** hit `getproperty(pars, Symbol(p.name))` once per descriptor per `build_model` call.
+- For a **`NamedTuple`**, `getproperty` is a fast, type-stable field access. LLVM often lowers this to the same load a hand-written `pars.μ` would use, but only after inlining through `value` — there is still a **`value` dispatch** and a **`Symbol(p.name)`** step (the name lives in a `String` field on the descriptor, not as a compile-time symbol).
+- For a **`ComponentArray`** or other custom `pars` type, lookup cost depends on that type's `getproperty` — worth profiling if the fit loop is hot.
+
+So: name-based access is **not** guaranteed to compile down to bare numbers in all cases, but for the usual `NamedTuple` fit vector it is **cheap relative to building a PDF**. The benchmark's simple-model ratios (~2–3× on an already sub-ns path) are mostly this dispatch + lookup stack, not a structural algorithmic cost.
+
+### 2. Nested construction and passing the full `pars`
+
+Nested models compose as `build_model(child, pars)` from parent bodies — the **same `pars` object** is forwarded to every sub-constructor (by reference; no copy).
+
+**Convenience cost:**
+
+- Each tree node runs its own **`build_model` method** (dynamic dispatch per constructor type).
+- Each node re-runs **`value(...; pars)`** for its own `::P` fields, even when only a leaf parameter changed.
+- **`Fixed` subtrees are rebuilt every iteration** — their numeric inputs are constants, but the user's `build_model` body (e.g. `Normal(...)`, `MixtureModel(...)`, `fft_convolve`) still runs unless the user structures code to avoid it.
+
+Depth therefore multiplies **dispatch + descriptor walks**, not `pars` copying. For deep trees with expensive leaves (PRB: BW + resolution + FFT), **leaf construction dominates**; the extra parent/child frames are a small fraction (~17% on `build_model` for the PRB case in the table below).
+
+### 3. Other sources (and non-sources)
+
+| Source | In fit loop? | Notes |
+| --- | --- | --- |
+| **`validate_parameters`** | No | Runs once when the constructor is created. |
+| **`running_*` / `parameter_*` collectors** | Should be no | Walk the tree and allocate `NamedTuple`s — sub-ns in benchmarks, but unnecessary inside `objective`. |
+| **Descriptor objects in the tree** | Persistent | Small heap structs (`Running`, `AdvancedParameter`, …); paid once, not per iteration. |
+| **Built-model allocations** | Yes | `Normal`, `MixtureModel`, FFT grids, etc. — same as hand-written code; usually **much larger** than BuildConstructors overhead. |
+| **Serialization (`serialize` / JSON)** | No | Separate workflow; not on the hot path. |
+
+**Not overhead:** wrapping or proxying the returned model; intercepting `pdf` / `logpdf`; copying the full parameter vector at each nesting level.
+
 ## Short answer
 
 | Concern | Verdict |

--- a/benchmark/OVERHEAD.md
+++ b/benchmark/OVERHEAD.md
@@ -1,0 +1,94 @@
+# BuildConstructors overhead
+
+BuildConstructors keeps fit metadata (names, bounds, fixed/free state) in a **constructor tree** and builds the domain model on demand via `build_model(constructor, pars)`. The question for fitting is: how much does that indirection cost at runtime and in memory?
+
+## Short answer
+
+| Concern | Verdict |
+| --- | --- |
+| **Fit-loop runtime** | Negligible for realistic models. On a full PRB physics model, one likelihood evaluation is **~9% slower** than hand-written construction; the extra `build_model` work is **~0.7 μs** on a **~4.4 μs** baseline. |
+| **Simple models** | `build_model` can be **~2–3× slower** than direct construction, but absolute time is **sub-nanosecond** per call — far below PDF/NLL cost. |
+| **Metadata API** | **`running_*` / `parameter_*` collectors are ~0.1–0.4 ns** per call. Use them at setup time, not inside the optimizer loop. |
+| **Memory** | The constructor tree is **~150–400 bytes** for the cases below. Built physics models are **~300 KiB** (FFT grids, interpolated PDFs). The package adds **no significant persistent memory** beyond the descriptor tree. |
+
+## How to reproduce
+
+```bash
+cd benchmark
+julia --project=. -e 'using Pkg; Pkg.develop(path=".."); Pkg.instantiate()'
+julia --project=. runbenchmarks.jl
+```
+
+Environment: Julia **1.11.5**, BuildConstructors **0.7.0**, Apple Silicon (aarch64), August 2026.
+
+## What is measured
+
+### 1. `build_model` vs hand-written baseline
+
+Each row compares `build_model(constructor, pars)` against equivalent code that reads `pars` directly and constructs the same object (no descriptors, no recursion).
+
+| Model | BuildConstructors | Baseline | Ratio |
+| --- | --- | --- | --- |
+| Gaussian (2 params) | ~0 ns | ~0 ns | 2.6× |
+| Nested mixture (5 params) | ~0 ns | ~0 ns | 2.6× |
+| PRB physics (1 running param) | 5.1 μs | 4.4 μs | 1.17× |
+| PRB from JSON (6 running params) | 4.5 μs | — | — |
+
+The PRB model includes Breit–Wigner integration, CrystalBall+sech resolution, Chebyshev background, and an FFT convolution (`grid_size = 10_000`). That dominates build time; descriptor lookup is a small fraction.
+
+### 2. One fit-iteration surrogate
+
+Simulates what an optimizer sees each step: **build model + evaluate likelihood on 1000 points**.
+
+| Model | BuildConstructors | Baseline | Ratio |
+| --- | --- | --- | --- |
+| Gaussian | ~0.1 ns | ~0.1 ns | 1.06× |
+| PRB physics | 4.7 μs | 4.3 μs | 1.09× |
+
+Once PDF evaluation is included, BuildConstructors overhead **shrinks to noise for simple models** and **~9% for heavy physics models**. In typical fits with thousands of events and many optimizer iterations, **likelihood evaluation dominates**; `build_model` is not the bottleneck.
+
+### 3. Metadata collectors (setup only)
+
+| Model | `running_values` | `running_names` | `parameter_metadata` |
+| --- | --- | --- | --- |
+| Gaussian | 0.1 ns | 0.0 ns | 0.0 ns |
+| Nested mixture | 0.3 ns | 0.2 ns | 0.1 ns |
+| PRB physics | 0.1 ns | 0.1 ns | 0.1 ns |
+| PRB from JSON | 0.3 ns | 0.3 ns | 0.2 ns |
+
+Call these **once** when setting up bounds, starting values, and fit vectors — not inside `objective(pars)`.
+
+### 4. Memory (`Base.summarysize`)
+
+| Model | Constructor | Built model | Notes |
+| --- | --- | --- | --- |
+| Gaussian | 148 B | 72 B | Constructor holds parameter descriptors + support tuple |
+| Nested mixture | 388 B | 264 B | Tree of nested constructors |
+| PRB physics | 177 B | 329 KiB | Model stores convolution grids |
+| PRB from JSON | 236 B | 293 KiB | Same: heavy objects live in the built model |
+
+The constructor is **persistent** (one per fit configuration). Built models are usually **recreated each iteration** and can be much larger; that cost exists with or without BuildConstructors.
+
+## Recommended usage pattern
+
+```julia
+# Setup (once)
+start = running_values(constructor)
+lower = running_lower_boundaries(constructor)
+upper = running_upper_boundaries(constructor)
+
+# Optimizer loop (many times)
+function objective(pars)
+    model = build_model(constructor, pars)
+    return -sum(logpdf.(Ref(model), data))
+end
+```
+
+Avoid calling `running_values`, `parameter_metadata`, or `fix!` inside `objective`.
+
+## When overhead might matter
+
+- **Very cheap objectives** where `build_model` runs on every call but likelihood evaluation is trivial (e.g. a handful of arithmetic operations). Consider caching the built model if parameters change in structured ways, or building only the sub-tree that depends on running parameters.
+- **Extremely deep constructor trees** with many nested `build_model` calls — profile if build time approaches evaluation time.
+
+For the intended use case — nested physics PDFs, extended likelihoods, and optimizers with hundreds/thousands of evaluations — **BuildConstructors overhead is small compared to model evaluation**.

--- a/benchmark/OVERHEAD.md
+++ b/benchmark/OVERHEAD.md
@@ -1,140 +1,40 @@
 # BuildConstructors overhead
 
-BuildConstructors keeps fit metadata (names, bounds, fixed/free state) in a **constructor tree** and builds the domain model on demand via `build_model(constructor, pars)`. The question for fitting is: how much does that indirection cost at runtime and in memory?
+Fit metadata lives in a constructor tree; each optimizer step calls `build_model(constructor, pars)`. Extra work is confined to that call (not PDF evaluation). Measured on Julia 1.11.5, BuildConstructors 0.7.0 (Apple Silicon, Aug 2026).
 
-## Where overhead comes from
+## Where it comes from
 
-BuildConstructors does not wrap the built model or intercept PDF calls. All extra work happens **inside `build_model`** (and, if misused, in metadata collectors). The main sources:
+1. **Parameter lookup** — `::P` fields become `value(descriptor; pars)`; running params use `getproperty(pars, Symbol(name))`, `Fixed` reads a stored constant. With `NamedTuple` this is usually cheap after inlining, but adds dispatch + `Symbol(name)` vs hand-written `pars.μ`.
+2. **Nested `build_model`** — the same `pars` is passed by reference to every child; each node pays dynamic dispatch and re-resolves its own descriptors. Fixed subtrees still re-run their build bodies each iteration.
+3. **Not in the hot path** — `validate_parameters` (once at construction), metadata collectors, serialization. Built-model allocations (`Normal`, FFT grids, …) dominate and match hand-written cost.
 
-### 1. Parameter lookup from `pars`
+## Verdict
 
-Running parameters are resolved by name. The macro-generated body starts with lines like `μ = value(c.description_of_μ; pars)`, and built-in descriptors implement:
-
-```julia
-value(p::Running; pars) = getproperty(pars, Symbol(p.name))
-value(p::Fixed; pars) = p.value   # ignores pars
-```
-
-**What this means in practice:**
-
-- **`Fixed` parameters** read a stored `Float64` — no `pars` access, essentially free.
-- **`Running` / free `FlexibleParameter` / free `AdvancedParameter`** hit `getproperty(pars, Symbol(p.name))` once per descriptor per `build_model` call.
-- For a **`NamedTuple`**, `getproperty` is a fast, type-stable field access. LLVM often lowers this to the same load a hand-written `pars.μ` would use, but only after inlining through `value` — there is still a **`value` dispatch** and a **`Symbol(p.name)`** step (the name lives in a `String` field on the descriptor, not as a compile-time symbol).
-- For a **`ComponentArray`** or other custom `pars` type, lookup cost depends on that type's `getproperty` — worth profiling if the fit loop is hot.
-
-So: name-based access is **not** guaranteed to compile down to bare numbers in all cases, but for the usual `NamedTuple` fit vector it is **cheap relative to building a PDF**. The benchmark's simple-model ratios (~2–3× on an already sub-ns path) are mostly this dispatch + lookup stack, not a structural algorithmic cost.
-
-### 2. Nested construction and passing the full `pars`
-
-Nested models compose as `build_model(child, pars)` from parent bodies — the **same `pars` object** is forwarded to every sub-constructor (by reference; no copy).
-
-**Convenience cost:**
-
-- Each tree node runs its own **`build_model` method** (dynamic dispatch per constructor type).
-- Each node re-runs **`value(...; pars)`** for its own `::P` fields, even when only a leaf parameter changed.
-- **`Fixed` subtrees are rebuilt every iteration** — their numeric inputs are constants, but the user's `build_model` body (e.g. `Normal(...)`, `MixtureModel(...)`, `fft_convolve`) still runs unless the user structures code to avoid it.
-
-Depth therefore multiplies **dispatch + descriptor walks**, not `pars` copying. For deep trees with expensive leaves (PRB: BW + resolution + FFT), **leaf construction dominates**; the extra parent/child frames are a small fraction (~17% on `build_model` for the PRB case in the table below).
-
-### 3. Other sources (and non-sources)
-
-| Source | In fit loop? | Notes |
-| --- | --- | --- |
-| **`validate_parameters`** | No | Runs once when the constructor is created. |
-| **`running_*` / `parameter_*` collectors** | Should be no | Walk the tree and allocate `NamedTuple`s — sub-ns in benchmarks, but unnecessary inside `objective`. |
-| **Descriptor objects in the tree** | Persistent | Small heap structs (`Running`, `AdvancedParameter`, …); paid once, not per iteration. |
-| **Built-model allocations** | Yes | `Normal`, `MixtureModel`, FFT grids, etc. — same as hand-written code; usually **much larger** than BuildConstructors overhead. |
-| **Serialization (`serialize` / JSON)** | No | Separate workflow; not on the hot path. |
-
-**Not overhead:** wrapping or proxying the returned model; intercepting `pdf` / `logpdf`; copying the full parameter vector at each nesting level.
-
-## Short answer
-
-| Concern | Verdict |
+| | |
 | --- | --- |
-| **Fit-loop runtime** | Negligible for realistic models. On a full PRB physics model, one likelihood evaluation is **~9% slower** than hand-written construction; the extra `build_model` work is **~0.7 μs** on a **~4.4 μs** baseline. |
-| **Simple models** | `build_model` can be **~2–3× slower** than direct construction, but absolute time is **sub-nanosecond** per call — far below PDF/NLL cost. |
-| **Metadata API** | **`running_*` / `parameter_*` collectors are ~0.1–0.4 ns** per call. Use them at setup time, not inside the optimizer loop. |
-| **Memory** | The constructor tree is **~150–400 bytes** for the cases below. Built physics models are **~300 KiB** (FFT grids, interpolated PDFs). The package adds **no significant persistent memory** beyond the descriptor tree. |
+| **Fit loop** | ~**9%** on a full PRB model (build + 1000× likelihood); ~**0.7 μs** extra on ~4.4 μs `build_model`. Simple models: ~2–3× on a sub-ns path — irrelevant next to NLL. |
+| **Metadata API** | Sub-ns; call at setup only, not in `objective`. |
+| **Memory** | Constructor tree ~**150–400 B**; built physics models ~**300 KiB** (grids). |
 
-## How to reproduce
+Likelihood evaluation dominates typical fits. Overhead matters only for trivial objectives or very deep trees where `build_model` rivals evaluation cost.
+
+## Results
+
+`build_model` vs hand-written baseline; fit step = build + likelihood on 1000 points.
+
+| Model | build (BC / baseline) | fit step ratio | constructor |
+| --- | --- | --- | --- |
+| Gaussian (2 p) | ~0 / ~0 ns (2.6×) | 1.06× | 148 B |
+| Nested mixture (5 p) | ~0 / ~0 ns (2.6×) | — | 388 B |
+| PRB physics (1 running) | 5.1 / 4.4 μs (1.17×) | 1.09× | 177 B |
+| PRB from JSON (6 running) | 4.5 μs | — | 236 B |
+
+PRB case: Breit–Wigner + CrystalBall/sech + Chebyshev + FFT (`grid_size = 10_000`). Leaf construction dominates; descriptor cost is a small fraction.
+
+## Reproduce
 
 ```bash
 cd benchmark
 julia --project=. -e 'using Pkg; Pkg.develop(path=".."); Pkg.instantiate()'
 julia --project=. runbenchmarks.jl
 ```
-
-Environment: Julia **1.11.5**, BuildConstructors **0.7.0**, Apple Silicon (aarch64), August 2026.
-
-## What is measured
-
-### 1. `build_model` vs hand-written baseline
-
-Each row compares `build_model(constructor, pars)` against equivalent code that reads `pars` directly and constructs the same object (no descriptors, no recursion).
-
-| Model | BuildConstructors | Baseline | Ratio |
-| --- | --- | --- | --- |
-| Gaussian (2 params) | ~0 ns | ~0 ns | 2.6× |
-| Nested mixture (5 params) | ~0 ns | ~0 ns | 2.6× |
-| PRB physics (1 running param) | 5.1 μs | 4.4 μs | 1.17× |
-| PRB from JSON (6 running params) | 4.5 μs | — | — |
-
-The PRB model includes Breit–Wigner integration, CrystalBall+sech resolution, Chebyshev background, and an FFT convolution (`grid_size = 10_000`). That dominates build time; descriptor lookup is a small fraction.
-
-### 2. One fit-iteration surrogate
-
-Simulates what an optimizer sees each step: **build model + evaluate likelihood on 1000 points**.
-
-| Model | BuildConstructors | Baseline | Ratio |
-| --- | --- | --- | --- |
-| Gaussian | ~0.1 ns | ~0.1 ns | 1.06× |
-| PRB physics | 4.7 μs | 4.3 μs | 1.09× |
-
-Once PDF evaluation is included, BuildConstructors overhead **shrinks to noise for simple models** and **~9% for heavy physics models**. In typical fits with thousands of events and many optimizer iterations, **likelihood evaluation dominates**; `build_model` is not the bottleneck.
-
-### 3. Metadata collectors (setup only)
-
-| Model | `running_values` | `running_names` | `parameter_metadata` |
-| --- | --- | --- | --- |
-| Gaussian | 0.1 ns | 0.0 ns | 0.0 ns |
-| Nested mixture | 0.3 ns | 0.2 ns | 0.1 ns |
-| PRB physics | 0.1 ns | 0.1 ns | 0.1 ns |
-| PRB from JSON | 0.3 ns | 0.3 ns | 0.2 ns |
-
-Call these **once** when setting up bounds, starting values, and fit vectors — not inside `objective(pars)`.
-
-### 4. Memory (`Base.summarysize`)
-
-| Model | Constructor | Built model | Notes |
-| --- | --- | --- | --- |
-| Gaussian | 148 B | 72 B | Constructor holds parameter descriptors + support tuple |
-| Nested mixture | 388 B | 264 B | Tree of nested constructors |
-| PRB physics | 177 B | 329 KiB | Model stores convolution grids |
-| PRB from JSON | 236 B | 293 KiB | Same: heavy objects live in the built model |
-
-The constructor is **persistent** (one per fit configuration). Built models are usually **recreated each iteration** and can be much larger; that cost exists with or without BuildConstructors.
-
-## Recommended usage pattern
-
-```julia
-# Setup (once)
-start = running_values(constructor)
-lower = running_lower_boundaries(constructor)
-upper = running_upper_boundaries(constructor)
-
-# Optimizer loop (many times)
-function objective(pars)
-    model = build_model(constructor, pars)
-    return -sum(logpdf.(Ref(model), data))
-end
-```
-
-Avoid calling `running_values`, `parameter_metadata`, or `fix!` inside `objective`.
-
-## When overhead might matter
-
-- **Very cheap objectives** where `build_model` runs on every call but likelihood evaluation is trivial (e.g. a handful of arithmetic operations). Consider caching the built model if parameters change in structured ways, or building only the sub-tree that depends on running parameters.
-- **Extremely deep constructor trees** with many nested `build_model` calls — profile if build time approaches evaluation time.
-
-For the intended use case — nested physics PDFs, extended likelihoods, and optimizers with hundreds/thousands of evaluations — **BuildConstructors overhead is small compared to model evaluation**.

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,19 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+BuildConstructors = "63b9b590-f22f-4e79-810f-ea9ba6849c26"
+ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+DistributionsHEP = "0d0d6f60-fb7b-48ca-90bb-e14e8b1655a7"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+NumericalDistributions = "13416b18-ec19-40e4-a123-e345ab61da74"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[compat]
+BenchmarkTools = "1"
+ComponentArrays = "0.15"
+Distributions = "0.25"
+DistributionsHEP = "0.5, 0.6"
+JSON = "1"
+NumericalDistributions = "0.5"
+julia = "1.9"

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,10 @@
+# Benchmarks
+
+Measure runtime and memory overhead of BuildConstructors relative to hand-written model construction.
+
+```bash
+julia --project=. -e 'using Pkg; Pkg.develop(path=".."); Pkg.instantiate()'
+julia --project=. runbenchmarks.jl
+```
+
+See [OVERHEAD.md](OVERHEAD.md) for interpreted results and guidance for fitting workflows.

--- a/benchmark/runbenchmarks.jl
+++ b/benchmark/runbenchmarks.jl
@@ -1,0 +1,364 @@
+using BenchmarkTools
+using BuildConstructors
+using ComponentArrays
+using Distributions
+using DistributionsHEP
+using JSON
+using NumericalDistributions
+using Printf
+using Statistics
+
+const Phys = BuildConstructors.physics_models_extension()
+Phys === nothing && error("Load BuildConstructors weak dependencies before running benchmarks.")
+
+const ConstructorOfBW = Phys.ConstructorOfBW
+const ConstructorOfCBpSECH = Phys.ConstructorOfCBpSECH
+const ConstructorOfGaussian = Phys.ConstructorOfGaussian
+const ConstructorOfPol1 = Phys.ConstructorOfPol1
+const ConstructorOfPRBModel = Phys.ConstructorOfPRBModel
+const load_prb_model_from_json = Phys.load_prb_model_from_json
+
+@with_parameters(BenchGauss; μ::P, σ::P, support::Tuple{Float64,Float64}, begin
+    truncated(Normal(μ, σ), support...)
+end)
+
+@with_parameters(BenchMixture; left, right, f_left::P, begin
+    MixtureModel(
+        [build_model(left, pars), build_model(right, pars)],
+        [f_left, 1 - f_left],
+    )
+end)
+
+function gaussian_direct(pars, support)
+    return truncated(Normal(pars.μ, pars.σ), support...)
+end
+
+function mixture_direct(pars)
+    left = truncated(Normal(pars.μ_left, pars.σ_left), -5.0, 5.0)
+    right = truncated(Normal(pars.μ_right, pars.σ_right), -5.0, 5.0)
+    return MixtureModel([left, right], [pars.f_left, 1 - pars.f_left])
+end
+
+function prb_direct(pars; grid_size = 10_000, support = (1.1, 2.5))
+    p = NumericallyIntegrable(
+        e -> 1 / abs2(3.8^2 - e^2 - 1im * 3.8 * 0.1),
+        (1.0, 2.6),
+    )
+    σ1, c0, c1, c2, n, s, fr1 = 0.002795, 2.48, 474.0, 8.1, 2.0, 1.3505, 0.5909
+    w = pars.w
+    σ2 = s * σ1
+    σ1_MeV, σ2_MeV = (σ1, σ2) .* 1e3
+    α = c0 * (c1 * σ1)^c2 / (1 + (c1 * σ1)^c2)
+    d1 = CrystalBall(0.0, σ1_MeV, α, n)
+    td1 = truncated(d1, support[1], support[2])
+    hyp_sec(x, μ, σ) = 1 / (2 * σ) * sech(π / 2 * (x - μ) / σ)
+    td2 = NumericallyIntegrable(x -> hyp_sec(x, 0.0, σ2_MeV), support)
+    r = w * MixtureModel([td1, td2], [fr1, 1 - fr1])
+    b = Chebyshev([1, 0.1], 1.0, 2.6)
+    r_conv_p = truncated(fft_convolve(r, p; gridsize = grid_size), support[1], support[2])
+    return MixtureModel([r_conv_p, b], [0.5, 0.5])
+end
+
+function make_gaussian_case()
+    support = (-0.5, 0.5)
+    constructor = ConstructorOfBenchGauss(
+        AdvancedParameter("μ", 0.0; boundaries = (-5.0, 5.0), uncertainty = 0.1),
+        AdvancedParameter("σ", 0.1; boundaries = (0.01, 5.0), uncertainty = 0.01),
+        support,
+    )
+    pars = (μ = 0.0, σ = 0.1)
+    return (; constructor, pars, support, label = "Gaussian (2 params)")
+end
+
+function make_mixture_case()
+    constructor = ConstructorOfBenchMixture(
+        ConstructorOfBenchGauss(
+            AdvancedParameter("μ_left", -0.5; boundaries = (-5.0, 5.0), uncertainty = 0.1),
+            AdvancedParameter("σ_left", 1.0; boundaries = (0.05, 5.0), uncertainty = 0.05),
+            (-5.0, 5.0),
+        ),
+        ConstructorOfBenchGauss(
+            AdvancedParameter("μ_right", 0.7; boundaries = (-5.0, 5.0), uncertainty = 0.1),
+            AdvancedParameter("σ_right", 1.0; boundaries = (0.05, 5.0), uncertainty = 0.05),
+            (-5.0, 5.0),
+        ),
+        AdvancedParameter("f_left", 0.5; boundaries = (0.0, 1.0), uncertainty = 0.02),
+    )
+    pars = (μ_left = -0.5, σ_left = 1.0, μ_right = 0.7, σ_right = 1.0, f_left = 0.5)
+    return (; constructor, pars, label = "Nested mixture (5 params)")
+end
+
+function make_prb_case()
+    constructor = ConstructorOfPRBModel(
+        Fixed(0.5),
+        ConstructorOfBW(Fixed(3.8), Fixed(0.1), (1.0, 2.6)),
+        ConstructorOfCBpSECH(
+            Fixed(0.002795),
+            Fixed(2.48),
+            Fixed(474),
+            Fixed(8.1),
+            Fixed(2.0),
+            Fixed(1.3505),
+            Fixed(0.5909),
+            Running("w"),
+            (-0.5, 0.5),
+        ),
+        ConstructorOfPol1(Fixed(0.1), (1.0, 2.6)),
+        (1.1, 2.5),
+        10_000,
+    )
+    pars = (w = 0.5,)
+    return (; constructor, pars, label = "PRB physics model (1 running param)")
+end
+
+function make_json_prb_case()
+    database = joinpath(@__DIR__, "..", "data", "database_test.json")
+    constructor, pars = load_prb_model_from_json(database, "bw", "CBpSECH", "Pol2")
+    return (; constructor, pars, label = "PRB from JSON (6 running params)")
+end
+
+function median_ns(bench)
+    return median(bench.times) / 1e3
+end
+
+function overhead_ratio(bc_ns, direct_ns)
+    return bc_ns / direct_ns
+end
+
+function memory_bytes(obj)
+    return Base.summarysize(obj)
+end
+
+function format_bytes(n::Integer)
+    if n >= 1_048_576
+        return @sprintf("%.2f MiB", n / 1_048_576)
+    elseif n >= 1024
+        return @sprintf("%.1f KiB", n / 1024)
+    else
+        return @sprintf("%d B", n)
+    end
+end
+
+function format_time(ns::Real)
+    if ns >= 1000
+        return @sprintf("%.2f μs", ns / 1000)
+    else
+        return @sprintf("%.1f ns", ns)
+    end
+end
+
+function benchmark_build(case; samples = 30, evals = 1)
+    constructor = case.constructor
+    pars = case.pars
+    fast = haskey(case, :support) || case.label == "Nested mixture (5 params)"
+    evals = fast ? 100 : evals
+
+    bc_bench = @benchmark build_model($constructor, $pars) samples = samples evals = evals
+
+    direct_bench = if haskey(case, :support)
+        support = case.support
+        @benchmark gaussian_direct($pars, $support) samples = samples evals = evals
+    elseif case.label == "Nested mixture (5 params)"
+        @benchmark mixture_direct($pars) samples = samples evals = evals
+    elseif case.label == "PRB physics model (1 running param)"
+        @benchmark prb_direct($pars) samples = samples evals = evals
+    else
+        nothing
+    end
+
+    bc_ns = median_ns(bc_bench) / evals
+    direct_ns = direct_bench === nothing ? missing : median_ns(direct_bench) / evals
+    ratio = direct_ns === missing ? missing : overhead_ratio(bc_ns, direct_ns)
+
+    model = build_model(constructor, pars)
+    return (;
+        label = case.label,
+        build_bc_ns = bc_ns,
+        build_direct_ns = direct_ns,
+        build_ratio = ratio,
+        constructor_bytes = memory_bytes(constructor),
+        model_bytes = memory_bytes(model),
+    )
+end
+
+function benchmark_metadata(case; samples = 100, evals = 10)
+    constructor = case.constructor
+    return (;
+        running_values = median_ns(@benchmark running_values($constructor) samples = samples evals = evals) / evals,
+        running_names = median_ns(@benchmark running_names($constructor) samples = samples evals = evals) / evals,
+        parameter_metadata = median_ns(@benchmark parameter_metadata($constructor) samples = samples evals = evals) / evals,
+    )
+end
+
+function evaluate_likelihood(model, x)
+    return -sum(logpdf.(Ref(model), x))
+end
+
+function benchmark_fit_step(case, x; samples = 20, evals = 1)
+    constructor = case.constructor
+    pars = case.pars
+    use_pdf = case.label == "PRB physics model (1 running param)"
+    fast = !use_pdf
+    evals = fast ? 50 : evals
+
+    bc_bench = if use_pdf
+        @benchmark begin
+            model = build_model($constructor, $pars)
+            sum(pdf.(Ref(model), $x))
+        end samples = samples evals = evals
+    else
+        @benchmark begin
+            model = build_model($constructor, $pars)
+            evaluate_likelihood(model, $x)
+        end samples = samples evals = evals
+    end
+
+    direct_bench = if haskey(case, :support)
+        support = case.support
+        @benchmark begin
+            model = gaussian_direct($pars, $support)
+            evaluate_likelihood(model, $x)
+        end samples = samples evals = evals
+    elseif use_pdf
+        @benchmark begin
+            model = prb_direct($pars)
+            sum(pdf.(Ref(model), $x))
+        end samples = samples evals = evals
+    else
+        nothing
+    end
+
+    bc_ns = median_ns(bc_bench) / evals
+    direct_ns = direct_bench === nothing ? missing : median_ns(direct_bench) / evals
+    ratio = direct_ns === missing ? missing : overhead_ratio(bc_ns, direct_ns)
+
+    return (;
+        label = case.label,
+        nll_bc_ns = bc_ns,
+        nll_direct_ns = direct_ns,
+        nll_ratio = ratio,
+    )
+end
+
+function print_table(title, rows, columns)
+    println()
+    println(title)
+    println("="^length(title))
+    headers = string.(columns)
+    col_widths = [
+        max(
+            length(headers[i]),
+            maximum(length(string(getproperty(row, col))) for row in rows),
+        ) for (i, col) in enumerate(columns)
+    ]
+    println(join((rpad(headers[i], col_widths[i]) for i in 1:length(columns)), " | "))
+    println("-"^(sum(col_widths) + 3 * (length(columns) - 1)))
+    for row in rows
+        values = String[]
+        for (i, col) in enumerate(columns)
+            val = getproperty(row, col)
+            sval = val === missing ? "—" : string(val)
+            push!(values, rpad(sval, col_widths[i]))
+        end
+        println(join(values, " | "))
+    end
+end
+
+function format_ratio(ratio)
+    ratio === missing && return "—"
+    return @sprintf("%.2fx", ratio)
+end
+
+function main()
+    cases = [make_gaussian_case(), make_mixture_case(), make_prb_case(), make_json_prb_case()]
+
+    build_rows = map(c -> begin
+        row = benchmark_build(c)
+        (;
+            label = row.label,
+            build_bc_ns = format_time(row.build_bc_ns),
+            build_direct_ns = row.build_direct_ns === missing ? missing : format_time(row.build_direct_ns),
+            build_ratio = format_ratio(row.build_ratio),
+        )
+    end, cases)
+    metadata_rows = [
+        begin
+            meta = benchmark_metadata(c)
+            (;
+                label = c.label,
+                running_values = format_time(meta.running_values),
+                running_names = format_time(meta.running_names),
+                parameter_metadata = format_time(meta.parameter_metadata),
+            )
+        end for c in cases
+    ]
+
+    x_gauss = randn(1000)
+    x_prb = 1.1 .+ 0.1 .* rand(1000)
+    fit_rows = [
+        begin
+            row = benchmark_fit_step(make_gaussian_case(), x_gauss)
+            (;
+                label = row.label,
+                nll_bc_ns = format_time(row.nll_bc_ns),
+                nll_direct_ns = row.nll_direct_ns === missing ? missing : format_time(row.nll_direct_ns),
+                nll_ratio = format_ratio(row.nll_ratio),
+            )
+        end,
+        begin
+            row = benchmark_fit_step(make_prb_case(), x_prb)
+            (;
+                label = row.label,
+                nll_bc_ns = format_time(row.nll_bc_ns),
+                nll_direct_ns = row.nll_direct_ns === missing ? missing : format_time(row.nll_direct_ns),
+                nll_ratio = format_ratio(row.nll_ratio),
+            )
+        end,
+    ]
+
+    println("BuildConstructors.jl overhead benchmark")
+    println("Julia ", VERSION)
+    println("BuildConstructors ", pkgversion(BuildConstructors))
+
+    print_table(
+        "build_model overhead (median, nanoseconds)",
+        build_rows,
+        (:label, :build_bc_ns, :build_direct_ns, :build_ratio),
+    )
+
+    print_table(
+        "Metadata collectors (median, nanoseconds; setup-time only)",
+        metadata_rows,
+        (:label, :running_values, :running_names, :parameter_metadata),
+    )
+
+    print_table(
+        "One fit evaluation: build + 1000× likelihood (median, nanoseconds)",
+        fit_rows,
+        (:label, :nll_bc_ns, :nll_direct_ns, :nll_ratio),
+    )
+
+    mem_rows = map(c -> begin
+        row = benchmark_build(c)
+        (;
+            label = row.label,
+            constructor = format_bytes(row.constructor_bytes),
+            model = format_bytes(row.model_bytes),
+            delta = format_bytes(row.constructor_bytes - row.model_bytes),
+        )
+    end, cases)
+    print_table(
+        "Approximate heap footprint (Base.summarysize)",
+        mem_rows,
+        (:label, :constructor, :model, :delta),
+    )
+
+    println()
+    println("Notes")
+    println("- Ratios > 1 mean BuildConstructors is slower than the hand-written baseline.")
+    println("- Metadata collectors are intended for setup, not per-iteration use.")
+    println("- The constructor tree is persistent state; built models are usually ephemeral.")
+    println("- PRB JSON case has no hand-written baseline; compare build_model time only.")
+end
+
+main()


### PR DESCRIPTION
## Summary
- Adds `benchmark/` with a reproducible suite comparing `build_model` and metadata collectors against hand-written baselines.
- Documents findings in `benchmark/OVERHEAD.md`: fit-loop overhead is ~9% on realistic PRB models; metadata calls are sub-ns; constructor memory is ~150–400 B.

## Test plan
- [x] `cd benchmark && julia --project=. -e 'using Pkg; Pkg.develop(path=".."); Pkg.instantiate()'`
- [x] `julia --project=. runbenchmarks.jl`

Made with [Cursor](https://cursor.com)