### PR TITLE
Fix serialize docstring attachment for Documenter

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -8,6 +8,16 @@ _type_name(::Type{T}) where {T} = string(nameof(T))
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
+function _serialized_value(c::Running; pars)
+    sym = Symbol(c.name)
+    hasproperty(pars, sym) ||
+        error("serialize($(typeof(c))): `pars` must contain $(repr(c.name))")
+    return getproperty(pars, sym)
+end
+
+_serialized_value(c::Union{FlexibleParameter,AdvancedParameter}; pars) =
+    hasproperty(pars, Symbol(c.name)) ? getproperty(pars, Symbol(c.name)) : c.value
+
 """
     serialize(constructor_or_parameter; pars=NamedTuple())
 
@@ -36,16 +46,6 @@ How each descriptor type obtains the stored number:
 Serialization is optional: the core constructor pattern works without it, but
 these methods are useful when descriptions need to be saved to JSON or a database.
 """
-function _serialized_value(c::Running; pars)
-    sym = Symbol(c.name)
-    hasproperty(pars, sym) ||
-        error("serialize($(typeof(c))): `pars` must contain $(repr(c.name))")
-    return getproperty(pars, sym)
-end
-
-_serialized_value(c::Union{FlexibleParameter,AdvancedParameter}; pars) =
-    hasproperty(pars, Symbol(c.name)) ? getproperty(pars, Symbol(c.name)) : c.value
-
 serialize(c::Fixed; pars=NamedTuple()) = LittleDict("type" => "Fixed", "value" => c.value)
 
 serialize(c::Running; pars=NamedTuple()) = LittleDict(


### PR DESCRIPTION
## Summary
- Move the `serialize` docstring from `_serialized_value` onto the first `serialize` method so Julia attaches it to the exported binding.
- Fixes Documenter failures in `@docs` blocks and `@ref` links that referenced `BuildConstructors.serialize`.

## Test plan
- [x] `julia --project=docs docs/make.jl` completes without `:docs_block` or `:cross_references` errors
- [ ] CI Docs workflow passes


Made with [Cursor](https://cursor.com)