### PR TITLE
Stop exporting common mutating helpers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BuildConstructors"
 uuid = "63b9b590-f22f-4e79-810f-ea9ba6849c26"
 authors = ["Robert Hentges <robert.hentges@cern.ch>"]
-version = "0.8.1"
+version = "0.9.0"
 
 [deps]
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -30,6 +30,13 @@ model = build_model(constructor, start)
 
 The constructor carries the metadata. The built object is just a `Normal`.
 
+The mutating helpers `fix!`, `release!`, and `update!` are intentionally not
+exported because their names are common. Import them explicitly when needed:
+
+```julia
+import BuildConstructors: fix!, release!, update!
+```
+
 ## Saving constructor trees
 
 See [Serialization](serialization.md) for round-trip persistence (JSON optional).

--- a/src/BuildConstructors.jl
+++ b/src/BuildConstructors.jl
@@ -5,9 +5,6 @@ using OrderedCollections
 # abstract parameter type
 # and two simple primitives
 
-export fix!
-export release!
-export update!
 export parameter_metadata
 export parameter_names
 export running_names

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,6 @@
 using Test
 using BuildConstructors
 
-@testset "Mutation helpers are not exported" begin
-    @test :fix! ∉ names(BuildConstructors)
-    @test :release! ∉ names(BuildConstructors)
-    @test :update! ∉ names(BuildConstructors)
-end
-
 @with_parameters(AffineCore; slope::P, intercept::P, begin
     x -> slope * x + intercept
 end)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,12 @@
 using Test
 using BuildConstructors
 
+@testset "Mutation helpers are not exported" begin
+    @test :fix! ∉ names(BuildConstructors)
+    @test :release! ∉ names(BuildConstructors)
+    @test :update! ∉ names(BuildConstructors)
+end
+
 @with_parameters(AffineCore; slope::P, intercept::P, begin
     x -> slope * x + intercept
 end)

--- a/test/test-parameter.jl
+++ b/test/test-parameter.jl
@@ -1,4 +1,5 @@
 using BuildConstructors
+import BuildConstructors: fix!, release!, update!
 using ComponentArrays
 using Test
 


### PR DESCRIPTION
## Summary

- stop exporting `fix!`, `release!`, and `update!`
- document how to import the mutating helpers explicitly
- bump the package version to `0.9.0`

## Why

These method names are common across Julia packages and can create avoidable name conflicts for users of `BuildConstructors`. Because removing exports is a breaking API change, this PR bumps the minor version to `0.9.0`. The functions remain public and can be imported with:

```julia
import BuildConstructors: fix!, release!, update!
```

Existing code that calls them as `BuildConstructors.fix!`, `BuildConstructors.release!`, or `BuildConstructors.update!` is unaffected. Code relying on `using BuildConstructors` to bring the unqualified names into scope will need the explicit import above.

## Validation

- `julia --project=. -e 'import Pkg; Pkg.test()'`
